### PR TITLE
Upstream merge + apply custom NetExec-specific patches to LDAP

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -48,11 +48,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10","3.11"]
+        python-version: ["3.9", "3.10","3.11","3.12"]
         experimental: [false]
         os: [ubuntu-latest]
         include:
-          - python-version: "3.12-dev"
+          - python-version: "3.13-dev"
             experimental: true
             os: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}

--- a/examples/smbexec.py
+++ b/examples/smbexec.py
@@ -56,7 +56,7 @@ from impacket import version, smbserver
 from impacket.dcerpc.v5 import transport, scmr
 from impacket.krb5.keytab import Keytab
 
-OUTPUT_FILENAME = '__output'
+OUTPUT_FILENAME = '__output_' + ''.join([random.choice(string.ascii_letters) for i in range(8)])
 SMBSERVER_DIR   = '__tmp'
 DUMMY_SHARE     = 'TMP'
 CODEC = sys.stdout.encoding

--- a/impacket/ldap/ldap.py
+++ b/impacket/ldap/ldap.py
@@ -24,6 +24,7 @@
 #
 
 import re
+import struct
 import socket
 from binascii import unhexlify
 import random
@@ -557,7 +558,7 @@ class LDAPConnection:
             self.sequenceNumber += 1
         return self._socket.sendall(data)
 
-    def recv(self):
+    def recv_raw(self):
         REQUEST_SIZE = 8192
         data = b''
         done = False
@@ -567,16 +568,31 @@ class LDAPConnection:
                 done = True
             data += recvData
 
+        if self.__binded and self.__signing: # we need to decrypt every TCP frames, all at once
+            message_length = struct.unpack('!I', data[:4])[0]
+
+            while message_length != len(data) - 4:
+                done = False
+                while not done:
+                    recvData = self._socket.recv(REQUEST_SIZE)
+                    if len(recvData) < REQUEST_SIZE:
+                        done = True
+                    data += recvData
+
+            data = self.decrypt(data)
+
+        return data
+
+    def recv(self):
         response = []
-        if self.__binded and self.__signing:
-                data = self.decrypt(data)
+        data = self.recv_raw()
         while len(data) > 0:
             try:
                 # need to decrypt before
                 message, remaining = decoder.decode(data, asn1Spec=LDAPMessage())
             except SubstrateUnderrunError:
                 # We need more data
-                remaining = data + self._socket.recv(REQUEST_SIZE)
+                remaining = data + self.recv_raw() 
             else:
                 if message['messageID'] == 0:  # unsolicited notification
                     name = message['protocolOp']['extendedResp']['responseName'] or message['responseName']

--- a/impacket/ldap/ldap.py
+++ b/impacket/ldap/ldap.py
@@ -105,6 +105,7 @@ class LDAPConnection:
             raise LDAPSessionError(errorString="Unknown URL prefix: '%s'" % url)
 
         self.__binded = False
+        self.__channel_binding_value = None
 
         ### SASL Auth LDAP Signing arguments
         self.sequenceNumber = 0
@@ -142,26 +143,25 @@ class LDAPConnection:
             self._socket.connect(sa)
             self._socket.do_handshake()
 
-    def generateChannelBindingValue(self):
-        # From: https://github.com/ly4k/ldap3/commit/87f5760e5a68c2f91eac8ba375f4ea3928e2b9e0#diff-c782b790cfa0a948362bf47d72df8ddd6daac12e5757afd9d371d89385b27ef6R1383
-        from hashlib import md5
-        # Ugly but effective, to get the digest of the X509 DER in bytes
-        peer_cert_digest_str = self._socket.get_peer_certificate().digest('sha256').decode()
-        peer_cert_digest_bytes = bytes.fromhex(peer_cert_digest_str.replace(':', ''))
-    
-        channel_binding_struct = b''
-        initiator_address = b'\x00'*8
-        acceptor_address = b'\x00'*8
+            # From: https://github.com/ly4k/ldap3/commit/87f5760e5a68c2f91eac8ba375f4ea3928e2b9e0#diff-c782b790cfa0a948362bf47d72df8ddd6daac12e5757afd9d371d89385b27ef6R1383
+            from hashlib import md5
+            # Ugly but effective, to get the digest of the X509 DER in bytes
+            peer_cert_digest_str = self._socket.get_peer_certificate().digest('sha256').decode()
+            peer_cert_digest_bytes = bytes.fromhex(peer_cert_digest_str.replace(':', ''))
+        
+            channel_binding_struct = b''
+            initiator_address = b'\x00'*8
+            acceptor_address = b'\x00'*8
 
-        # https://datatracker.ietf.org/doc/html/rfc5929#section-4
-        application_data_raw = b'tls-server-end-point:' + peer_cert_digest_bytes
-        len_application_data = len(application_data_raw).to_bytes(4, byteorder='little', signed = False)
-        application_data = len_application_data
-        application_data += application_data_raw
-        channel_binding_struct += initiator_address
-        channel_binding_struct += acceptor_address
-        channel_binding_struct += application_data
-        return md5(channel_binding_struct).digest()
+            # https://datatracker.ietf.org/doc/html/rfc5929#section-4
+            application_data_raw = b'tls-server-end-point:' + peer_cert_digest_bytes
+            len_application_data = len(application_data_raw).to_bytes(4, byteorder='little', signed = False)
+            application_data = len_application_data
+            application_data += application_data_raw
+            channel_binding_struct += initiator_address
+            channel_binding_struct += acceptor_address
+            channel_binding_struct += application_data
+            self.__channel_binding_value = md5(channel_binding_struct).digest()
 
     def kerberosLogin(self, user, password, domain='', lmhash='', nthash='', aesKey='', kdcHost=None, TGT=None,
                       TGS=None, useCache=True):
@@ -269,8 +269,8 @@ class LDAPConnection:
 
         # If TLS is used, setup channel binding
         
-        if self._SSL:
-            chkField['Bnd'] = self.generateChannelBindingValue()
+        if self._SSL and self.__channel_binding_value is not None:
+            chkField['Bnd'] = self.__channel_binding_value
         if self.__signing:
             chkField['Flags'] |= GSS_C_CONF_FLAG
             chkField['Flags'] |= GSS_C_INTEG_FLAG
@@ -373,8 +373,8 @@ class LDAPConnection:
 
             # If TLS is used, setup channel binding
             channel_binding_value = b''
-            if self._SSL:
-                channel_binding_value = self.generateChannelBindingValue()
+            if self._SSL and self.__channel_binding_value is not None:
+                channel_binding_value = self.__channel_binding_value
 
             # NTLM Auth
             type3, exportedSessionKey = getNTLMSSPType3(negotiate, bytes(type2), user, password, domain, lmhash, nthash, channel_binding_value=channel_binding_value)
@@ -419,8 +419,8 @@ class LDAPConnection:
             
             # channel binding
             channel_binding_value = b''
-            if self._SSL:
-                channel_binding_value = self.generateChannelBindingValue()
+            if self._SSL and self.__channel_binding_value is not None:
+                channel_binding_value = self.__channel_binding_value
             
             # NTLM Auth
             type3, exportedSessionKey = getNTLMSSPType3(negotiate, type2, user, password, domain, lmhash, nthash, service='ldap', version=self.version, use_ntlmv2=True, channel_binding_value=channel_binding_value)

--- a/impacket/ldap/ldapasn1.py
+++ b/impacket/ldap/ldapasn1.py
@@ -161,7 +161,7 @@ class AttributeValue(univ.OctetString):
 
 
 class AssertionValue(univ.OctetString):
-    pass
+    encoding = 'utf-8'
 
 
 class MatchingRuleID(LDAPString):

--- a/impacket/smb.py
+++ b/impacket/smb.py
@@ -814,6 +814,8 @@ class SMBCommand(Structure):
 class AsciiOrUnicodeStructure(Structure):
     UnicodeStructure = ()
     AsciiStructure   = ()
+    ENCODING = 'utf-8'
+
     def __init__(self, flags = 0, **kargs):
         if flags & SMB.FLAGS2_UNICODE:
             self.structure = self.UnicodeStructure

--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -4887,9 +4887,10 @@ class SimpleSMBServer:
     :param string configFile: a file with all the servers' configuration. If no file specified, this class will create the basic parameters needed to run. You will need to add your shares manually tho. See addShare() method
     """
 
-    def __init__(self, listenAddress='0.0.0.0', listenPort=445, configFile=''):
+    def __init__(self, listenAddress='0.0.0.0', listenPort=445, configFile='', smbserverclass=SMBSERVER):
         if configFile != '':
-            self.__server = SMBSERVER((listenAddress, listenPort))
+            #self.__server = SMBSERVER((listenAddress, listenPort))
+            self.__server = smbserverclass((listenAddress, listenPort))
             self.__server.processConfigFile(configFile)
             self.__smbConfig = None
         else:
@@ -4914,7 +4915,7 @@ class SimpleSMBServer:
             self.__smbConfig.set('IPC$', 'read only', 'yes')
             self.__smbConfig.set('IPC$', 'share type', '3')
             self.__smbConfig.set('IPC$', 'path', '')
-            self.__server = SMBSERVER((listenAddress, listenPort), config_parser=self.__smbConfig)
+            self.__server = smbserverclass((listenAddress, listenPort), config_parser=self.__smbConfig)
             self.__server.processConfigFile()
 
         # Now we have to register the MS-SRVS server. This specially important for
@@ -4922,11 +4923,14 @@ class SimpleSMBServer:
         # ask for shares using MS-RAP.
 
         self.__srvsServer = SRVSServer()
-        self.__srvsServer.daemon = True
+        self.__srvsServer.daemon=True
         self.__wkstServer = WKSTServer()
-        self.__wkstServer.daemon = True
+        self.__wkstServer.daemon=True
         self.__server.registerNamedPipe('srvsvc', ('127.0.0.1', self.__srvsServer.getListenPort()))
         self.__server.registerNamedPipe('wkssvc', ('127.0.0.1', self.__wkstServer.getListenPort()))
+
+    def getServer(self):
+        return self.__server
 
     def start(self):
         self.__srvsServer.start()

--- a/impacket/structure.py
+++ b/impacket/structure.py
@@ -12,6 +12,8 @@
 from __future__ import division
 from __future__ import print_function
 from struct import pack, unpack, calcsize
+
+import six
 from six import b, PY3
 from binascii import hexlify
 
@@ -80,6 +82,9 @@ class Structure:
     commonHdr = ()
     structure = ()
     debug = 0
+    # Encoding defaults to latin-1 which already was the de facto encoding for structures and works for most use cases.
+    # Now it can be configured to another encoding if needed.
+    ENCODING = 'latin-1'   # https://github.com/fortra/impacket/pull/1958
 
     def __init__(self, data = None, alignment = 0):
         if not hasattr(self, 'alignment'):
@@ -87,6 +92,9 @@ class Structure:
 
         self.fields    = {}
         self.rawData   = data
+
+        self.b = lambda x: six.ensure_binary(x, encoding=self.ENCODING)
+
         if data is not None:
             self.fromString(data)
         else:
@@ -197,7 +205,7 @@ class Structure:
 
         # quote specifier
         if format[:1] == "'" or format[:1] == '"':
-            return b(format[1:])
+            return self.b(format[1:])
 
         # code specifier
         two = format.split('=')
@@ -245,26 +253,26 @@ class Structure:
         # "printf" string specifier
         if format[:1] == '%':
             # format string like specifier
-            return b(format % data)
+            return self.b(format % data)
 
         # asciiz specifier
         if format[:1] == 'z':
             if isinstance(data,bytes):
-                return data + b('\0')
-            return bytes(b(data)+b('\0'))
+                return data + self.b('\0')
+            return bytes(self.b(data)+self.b('\0'))
 
         # unicode specifier
         if format[:1] == 'u':
-            return bytes(data+b('\0\0') + (len(data) & 1 and b('\0') or b''))
+            return bytes(data+self.b('\0\0') + (len(data) & 1 and self.b('\0') or b''))
 
         # DCE-RPC/NDR string specifier
         if format[:1] == 'w':
             if len(data) == 0:
-                data = b('\0\0')
+                data = self.b('\0\0')
             elif len(data) % 2:
-                data = b(data) + b('\0')
+                data = self.b(data) + self.b('\0')
             l = pack('<L', len(data)//2)
-            return b''.join([l, l, b('\0\0\0\0'), data])
+            return b''.join([l, l, self.b('\0\0\0\0'), data])
 
         if data is None:
             raise Exception("Trying to pack None")
@@ -279,7 +287,7 @@ class Structure:
             elif isinstance(data, int):
                 return bytes(data)
             elif isinstance(data, bytes) is not True:
-                return bytes(b(data))
+                return bytes(self.b(data))
             else:
                 return data
 
@@ -288,7 +296,7 @@ class Structure:
             if isinstance(data, bytes) or isinstance(data, bytearray):
                 return pack(format, data)
             else:
-                return pack(format, b(data))
+                return pack(format, self.b(data))
 
         # struct like specifier
         return pack(format, data)
@@ -315,7 +323,7 @@ class Structure:
         # quote specifier
         if format[:1] == "'" or format[:1] == '"':
             answer = format[1:]
-            if b(answer) != data:
+            if self.b(answer) != data:
                 raise Exception("Unpacked data doesn't match constant value '%r' should be '%r'" % (data, answer))
             return answer
 
@@ -361,7 +369,7 @@ class Structure:
 
         # asciiz specifier
         if format == 'z':
-            if data[-1:] != b('\x00'):
+            if data[-1:] != self.b('\x00'):
                 raise Exception("%s 'z' field is not NUL terminated: %r" % (field, data))
             if PY3:
                 return data[:-1].decode('latin-1')
@@ -370,7 +378,7 @@ class Structure:
 
         # unicode specifier
         if format == 'u':
-            if data[-2:] != b('\x00\x00'):
+            if data[-2:] != self.b('\x00\x00'):
                 raise Exception("%s 'u' field is not NUL-NUL terminated: %r" % (field, data))
             return data[:-2] # remove trailing NUL
 
@@ -524,11 +532,11 @@ class Structure:
 
         # asciiz specifier
         if format[:1] == 'z':
-            return data.index(b('\x00'))+1
+            return data.index(self.b('\x00'))+1
 
         # asciiz specifier
         if format[:1] == 'u':
-            l = data.index(b('\x00\x00'))
+            l = data.index(self.b('\x00\x00'))
             return l + (l & 1 and 3 or 2)
 
         # DCE-RPC/NDR string specifier
@@ -584,7 +592,7 @@ class Structure:
         if format in ['z',':','u']:
             return b''
         if format == 'w':
-            return b('\x00\x00')
+            return self.b('\x00\x00')
 
         return 0
 


### PR DESCRIPTION
Integrated changes to LDAP from https://github.com/Pennyw0rth/impacket/pull/12 and https://github.com/Pennyw0rth/impacket/commit/4983c4d44804a924b53fd3541a2b748f3bbb8cda to ensure continuity between recent changes to NetExec and its dependency on Impacket. 

These changes make LDAP receive operations more reliable on large responses where signing is enabled, as well as apply an encoding patch to handle non-ascii characters in LDAP queries.