### PR TITLE
Resolve initial CBT value error

### DIFF
--- a/impacket/ldap/ldap.py
+++ b/impacket/ldap/ldap.py
@@ -269,7 +269,9 @@ class LDAPConnection:
 
         # If TLS is used, setup channel binding
         
-        if self._SSL and self.__channel_binding_value is not None:
+        if self._SSL:
+            if self.__channel_binding_value is None:
+                self.__channel_binding_value = self.generateChannelBindingValue()
             chkField['Bnd'] = self.__channel_binding_value
         if self.__signing:
             chkField['Flags'] |= GSS_C_CONF_FLAG


### PR DESCRIPTION
Patch to ensure `self.__channel_binding_value` is always set before use with NetExec ldap protocol, defined within this impacket dependency file. The current logic relies on the value being pre-populated after an initial bind, leading to errors on first use.

Before:
![image](https://github.com/user-attachments/assets/8ea7ae21-ab4c-4622-934d-231b711e8a9b)

After:
![image](https://github.com/user-attachments/assets/02e41d61-9973-459b-aa0d-c0dd074d2e7d)

